### PR TITLE
Add 'Start here' help panel to filters and remove header help/stats icons

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -187,8 +187,6 @@ export default function App() {
   return (
     <div className="min-h-full">
       <Header
-        onOpenHelp={() => {}}
-        onOpenStats={() => {}}
         onOpenFilters={() => setFiltersOpen(true)}
       />
 

--- a/src/components/FiltersPanel.jsx
+++ b/src/components/FiltersPanel.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Zap, Filter } from "lucide-react";
+import { HelpCircle, Zap, Filter } from "lucide-react";
 import AppIcon from "./icons/AppIcon";
 import { useI18n } from "../i18n/I18nContext";
 import { cn } from "../lib/cn";
@@ -91,7 +91,37 @@ export default function FiltersPanel({
 
   return (
     <div className={cn("space-y-8 py-2 px-1", className)}>
-      <Accordion className="w-full" collapsible defaultValue="item-quick" type="single">
+      <Accordion className="w-full" collapsible defaultValue="item-start" type="single">
+        <AccordionItem value="item-start">
+          <AccordionTrigger>
+            <div className="flex items-center gap-3">
+              <AppIcon
+                icon={HelpCircle}
+                className="h-5 w-5 text-primary"
+                aria-hidden="true"
+              />
+              <span className="text-base font-bold text-foreground">
+                {t("startHereTitle")}
+              </span>
+            </div>
+          </AccordionTrigger>
+          <AccordionContent>
+            <GlassPanel className="p-4 space-y-3">
+              <p className="text-sm text-foreground font-semibold">
+                {t("startHereSubtitle")}
+              </p>
+              <p className="text-sm text-muted-foreground">
+                {t("startHereIntro")}
+              </p>
+              <ul className="text-sm text-muted-foreground space-y-2 list-disc pl-5">
+                <li>{t("startHereStepPick")}</li>
+                <li>{t("startHereStepRefine")}</li>
+                <li>{t("startHereStepPractice")}</li>
+              </ul>
+            </GlassPanel>
+          </AccordionContent>
+        </AccordionItem>
+
         <AccordionItem value="item-quick">
           <AccordionTrigger>
             <div className="flex items-center gap-3">

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useI18n } from "../i18n/I18nContext";
 import CymruRibbon from "./CymruRibbon";
-import { HelpCircle, BarChart3, Filter } from "lucide-react";
+import { Filter } from "lucide-react";
 import AppIcon from "./icons/AppIcon";
 import { Button } from "./ui/button";
 import { Switch } from "./ui/switch";
@@ -14,8 +14,6 @@ import {
 import { cn } from "../lib/cn";
 
 export default function Header({
-  onOpenHelp,
-  onOpenStats,
   onOpenFilters,
 }) {
   const { lang, setLang, t } = useI18n();
@@ -76,49 +74,6 @@ export default function Header({
 
             {/* Separator */}
             <div className="hidden min-[400px]:block h-4 w-px bg-border" />
-
-            {/* Icon buttons: help, stats */}
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={onOpenHelp}
-                  aria-label={t("headerHelp") || "Help"}
-                  className="h-8 w-8 sm:h-9 sm:w-9 text-primary hover:bg-[hsl(var(--rail))]/70"
-                >
-                  <AppIcon
-                    icon={HelpCircle}
-                    className="h-4 w-4 sm:h-5 sm:w-5"
-                    aria-hidden="true"
-                  />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">
-                {t("headerHelp") || "Help"}
-              </TooltipContent>
-            </Tooltip>
-
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={onOpenStats}
-                  aria-label={t("headerStats") || "Stats"}
-                  className="h-8 w-8 sm:h-9 sm:w-9 text-primary hover:bg-[hsl(var(--rail))]/70"
-                >
-                  <AppIcon
-                    icon={BarChart3}
-                    className="h-4 w-4 sm:h-5 sm:w-5"
-                    aria-hidden="true"
-                  />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">
-                {t("headerStats") || "Stats"}
-              </TooltipContent>
-            </Tooltip>
 
             {/* Mobile filters button */}
             <Tooltip>

--- a/src/i18n/strings.js
+++ b/src/i18n/strings.js
@@ -47,6 +47,13 @@ export const STRINGS = {
     headerClearFocus: "Clirio ffocws",
     headerSwitchLang: "Newid iaith",
 
+    startHereTitle: "Dechrau yma",
+    startHereSubtitle: "Canllaw cyflym i ddechrau.",
+    startHereIntro: "Dewiswch becyn neu addaswch yr hidlwyr i siapio eich sesiwn.",
+    startHereStepPick: "Dewiswch becyn cyflym i neidio i bwnc.",
+    startHereStepRefine: "Addaswch y math o dreiglad a’r categorïau isod.",
+    startHereStepPractice: "Ymarferwch, gwrandewch, a defnyddiwch awgrymiadau wrth i chi fynd.",
+
     quickPacksTitle: "Pecynnau cyflym",
     quickPacksSubtitle: "Dechreuwch gyda phecyn neu addaswch isod.",
     quickPacksHint: "Setiau dan arweiniad i neidio i bwnc.",
@@ -121,6 +128,13 @@ export const STRINGS = {
     headerNoFocus: "No focus",
     headerClearFocus: "Clear focus",
     headerSwitchLang: "Switch language",  
+
+    startHereTitle: "Start here",
+    startHereSubtitle: "A quick guide to get going.",
+    startHereIntro: "Pick a pack or adjust the filters to shape your session.",
+    startHereStepPick: "Choose a quick pack to jump into a topic.",
+    startHereStepRefine: "Refine mutation type and categories below.",
+    startHereStepPractice: "Practice, listen, and use hints as you go.",
 
     quickPacksTitle: "Quick packs",
     quickPacksSubtitle: "Start with a pack or fine-tune below.",


### PR DESCRIPTION
### Motivation
- The header contained Help and Stats icons that do not link anywhere and clutter the control area.  
- Onboarding/help should live in the right-hand filters accordion so new users can discover guidance where they refine sessions.  
- Keep the UI consistent with the app's existing accordion/GlassPanel styles and localized strings.

### Description
- Removed the Help and Stats icon buttons and their props from `Header` and stopped passing unused `onOpenHelp`/`onOpenStats` handlers from `App` so the header surface is simplified.  
- Added a new `Start here` accordion item at the top of the filters panel in `FiltersPanel` that contains onboarding text and a short 3-step list, using the same `GlassPanel`/accordion styling as the rest of the panel.  
- Added localized copy keys for the new content (`startHere*`) to `src/i18n/strings.js` for both English and Welsh and wired the text via `useI18n` in the panel.  
- Set the filters accordion default to open the new `item-start` entry so the onboarding is visible by default on desktop and in the filters sheet.

### Testing
- Started the dev server with `npm run dev` and confirmed Vite served the app successfully on port 4173. (succeeded)  
- Captured a full-page UI screenshot via Playwright to verify the `Start here` accordion renders above the pack/filter headings and is styled consistently. (succeeded)  
- No unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69835b8160608324a913a0ff68859474)