### PR TITLE
Refine header wordmark lockup

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { useI18n } from "../i18n/I18nContext";
-import CymruRibbon from "./CymruRibbon";
 import { Filter } from "lucide-react";
 import AppIcon from "./icons/AppIcon";
 import { Button } from "./ui/button";
@@ -24,25 +23,30 @@ export default function Header({
       <div className="mx-auto flex max-w-6xl items-center justify-between gap-2 sm:gap-4 px-3 py-2 sm:px-6 sm:py-3 lg:py-3.5">
         
         {/* Logo lockup: dragon + wordmark */}
-        <div className="flex items-center gap-[-0.5] min-w-0 shrink">
+        <div className="brandLockup flex items-baseline min-w-0 shrink">
           <img
             src="dragon.png"
             alt=""
-            className="h-8 w-8 sm:h-10 sm:w-10 lg:h-12 lg:w-12 xl:h-14 xl:w-14 drop-shadow-sm flex-shrink-0"
+            className="brandMark drop-shadow-sm flex-shrink-0"
             aria-hidden="true"
           />
           <h1
-            className="text-2xl sm:text-3xl lg:text-4xl xl:text-5xl uppercase tracking-[-0.03em] leading-tight flex items-center gap--0.5
-            "
+            className="text-2xl sm:text-3xl lg:text-4xl xl:text-5xl uppercase leading-none whitespace-nowrap"
             style={{
               fontFamily:
                 "'BBH Bogle', 'bbh-bogle-regular', 'Bogle', 'Poppins', 'Inter', sans-serif",
             }}
           >
-            <span className="text-[hsl(var(--cymru-green))]">
-              Hyfforddwr
+            <span className="brandWordmark" aria-label="HYFFORDDWR TREIGLAD">
+              <span className="brandWord brandWord--primary text-[hsl(var(--cymru-green))]">
+                <span className="brandWordPart">HYFFORDD</span>
+                <span className="brandWordPart brandWordPart--kern">WR</span>
+              </span>
+              <span className="brandGap" aria-hidden="true" />
+              <span className="brandWord brandWord--secondary text-destructive">
+                TREIGLAD
+              </span>
             </span>
-            <span className="text-destructive">Treiglad</span>
           </h1>
         </div>
 

--- a/src/index.css
+++ b/src/index.css
@@ -181,6 +181,46 @@
     @apply bg-[hsl(var(--rail))] border border-border/50 rounded-[calc(var(--radius)-2px)];
   }
 
+  .brandLockup {
+    column-gap: 0.45em;
+  }
+
+  .brandMark {
+    width: 0.95em;
+    height: 0.95em;
+    transform: translateY(1px);
+  }
+
+  .brandWordmark {
+    display: inline-flex;
+    align-items: baseline;
+    font-kerning: normal;
+    font-feature-settings: "kern" 1, "liga" 1, "calt" 1;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: geometricPrecision;
+  }
+
+  .brandWord {
+    display: inline-flex;
+  }
+
+  .brandWord--primary {
+    letter-spacing: 0.015em;
+  }
+
+  .brandWord--secondary {
+    letter-spacing: 0.04em;
+  }
+
+  .brandGap {
+    display: inline-block;
+    width: 0.26em;
+  }
+
+  .brandWordPart--kern {
+    margin-left: 0.03em;
+  }
+
   .mt-pill {
     font-size: var(--text-label-size);
     line-height: var(--text-label-line);


### PR DESCRIPTION
### Motivation
- Turn the header text + dragon into a single, designed lockup while respecting the constraint of a single BBH Bogle weight and all-caps Welsh colour split. 
- Fix optical spacing, tracking, word-gap and icon alignment so the mark reads as one premium logotype instead of two loud blocks.

### Description
- Reworked the Header markup to a strict brand lockup: added `brandLockup`, `brandMark` and `brandWordmark` structure and split the primary word into `HYFFORDD` + `WR` for micro-kerning control (file: `src/components/Header.jsx`).
- Added CSS rules in `src/index.css` to enable kerning/features and optical rendering (`font-kerning`, `font-feature-settings`, `-webkit-font-smoothing`, `text-rendering`) under `.brandWordmark` and to prevent wrapping with tight leading (`whitespace-nowrap` / `leading-none`).
- Applied explicit tracking and gap values via new classes: `brandWord--primary` uses letter-spacing `0.015em`, `brandWord--secondary` uses `0.04em`, and `brandGap` width is `0.26em` (em-based so it scales with font-size).  
- Implemented micro-kerning on the terminal pair by splitting `HYFFORDDWR` into `HYFFORDD` + `WR` and adding `.brandWordPart--kern { margin-left: 0.03em }`; sized and optically aligned the icon with `.brandMark { width: 0.95em; height: 0.95em; transform: translateY(1px); }`.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and confirmed it launched without runtime errors.  
- Captured a visual snapshot using a Playwright script which navigated to the dev server and produced `artifacts/header-wordmark.png`, indicating the lockup rendered successfully.  
- All automated steps succeeded (dev server start and screenshot); visual review is recommended to validate optical tweaks across breakpoints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983696a315c832497ea78423be73ebf)