### PR TITLE
Enlarge header brand mark and refine lockup spacing

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -23,11 +23,11 @@ export default function Header({
       <div className="mx-auto flex max-w-6xl items-center justify-between gap-2 sm:gap-4 px-3 py-2 sm:px-6 sm:py-3 lg:py-3.5">
         
         {/* Logo lockup: dragon + wordmark */}
-        <div className="brandLockup flex items-baseline min-w-0 shrink">
+        <div className="brandLockup flex items-baseline min-w-0 shrink whitespace-nowrap">
           <img
             src="dragon.png"
             alt=""
-            className="brandMark drop-shadow-sm flex-shrink-0"
+            className="brandMark h-7 w-auto sm:h-8 md:h-9 lg:h-10 flex-shrink-0"
             aria-hidden="true"
           />
           <h1
@@ -38,12 +38,12 @@ export default function Header({
             }}
           >
             <span className="brandWordmark" aria-label="HYFFORDDWR TREIGLAD">
-              <span className="brandWord brandWord--primary text-[hsl(var(--cymru-green))]">
+              <span className="brandPrimary text-[hsl(var(--cymru-green))]">
                 <span className="brandWordPart">HYFFORDD</span>
                 <span className="brandWordPart brandWordPart--kern">WR</span>
               </span>
               <span className="brandGap" aria-hidden="true" />
-              <span className="brandWord brandWord--secondary text-destructive">
+              <span className="brandSecondary text-destructive">
                 TREIGLAD
               </span>
             </span>

--- a/src/index.css
+++ b/src/index.css
@@ -182,13 +182,13 @@
   }
 
   .brandLockup {
-    column-gap: 0.45em;
+    column-gap: 0.5em;
   }
 
   .brandMark {
-    width: 0.95em;
-    height: 0.95em;
-    transform: translateY(1px);
+    position: relative;
+    top: 1px;
+    image-rendering: -webkit-optimize-contrast;
   }
 
   .brandWordmark {
@@ -200,21 +200,29 @@
     text-rendering: geometricPrecision;
   }
 
-  .brandWord {
+  .brandPrimary {
     display: inline-flex;
+    letter-spacing: 0.018em;
   }
 
-  .brandWord--primary {
-    letter-spacing: 0.015em;
-  }
-
-  .brandWord--secondary {
+  .brandSecondary {
+    display: inline-flex;
     letter-spacing: 0.04em;
   }
 
   .brandGap {
     display: inline-block;
-    width: 0.26em;
+    width: 0.28em;
+  }
+
+  @media (max-width: 640px) {
+    .brandLockup {
+      column-gap: 0.36em;
+    }
+
+    .brandGap {
+      width: 0.22em;
+    }
   }
 
   .brandWordPart--kern {


### PR DESCRIPTION
### Motivation
- Make the dragon mark visibly larger and optically aligned to the BBH Bogle wordmark while preserving the wordmark font, all-caps treatment, and color tokens. 
- Improve lockup spacing and tracking so the header reads as a designed logo across breakpoints without introducing new assets or changing font sizes.

### Description
- Set explicit responsive Tailwind sizing on the dragon image in `src/components/Header.jsx` to `h-7 sm:h-8 md:h-9 lg:h-10 w-auto`, added `whitespace-nowrap` to the lockup, and removed the decorative `drop-shadow-sm` so the mark scales predictably. 
- Tuned CSS in `src/index.css`: increased lockup `column-gap` to `0.5em`, set `.brandMark { top: 1px; image-rendering: -webkit-optimize-contrast; }`, and removed prior hard `em` sizing so the Tailwind heights govern scale. 
- Adjusted wordmark micro‑typography: `letter-spacing` is now `0.018em` for the primary word and `0.04em` for the secondary, added `.brandGap` widths `0.28em` (desktop) / `0.22em` (≤640px), and preserved the micro-kern `margin-left: 0.03em` on the trailing “WR”. 
- Preserved the existing wordmark font family and font-size utilities (`text-2xl sm:text-3xl lg:text-4xl xl:text-5xl`) and kept color usage to tokens `text-[hsl(var(--cymru-green))]` and `text-destructive` only.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and the site served successfully. 
- Captured a visual verification screenshot using Playwright at `artifacts/header-lockup-updated.png`, which completed without error. 
- No automated unit tests were changed or added for this purely visual update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69836d6060408324bce8f1e4d2fadd7c)