### PR TITLE
Align logo baseline with wordmark

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -20,14 +20,14 @@ export default function Header({
 
   return (
     <header className="sticky top-0 z-40 backdrop-blur bg-card" style={{ boxShadow: '0 1px 3px 0 rgb(0 0 0 / 0.05), 0 1px 2px -1px rgb(0 0 0 / 0.05)' }}>
-      <div className="mx-auto flex max-w-6xl items-center justify-between gap-2 sm:gap-4 px-3 py-2 sm:px-6 sm:py-3 lg:py-3.5">
+      <div className="mx-auto flex max-w-6xl items-end justify-between gap-2 sm:gap-4 px-3 pt-2 pb-2.5 sm:px-6 sm:pt-3 sm:pb-3 lg:pb-3.5">
         
         {/* Logo lockup: dragon + wordmark */}
-        <div className="brandLockup flex items-baseline min-w-0 shrink whitespace-nowrap">
+        <div className="brandLockup flex items-end min-w-0 shrink whitespace-nowrap">
           <img
             src="dragon.png"
             alt=""
-            className="brandMark h-7 w-auto sm:h-8 md:h-9 lg:h-10 flex-shrink-0"
+            className="brandMark h-8 w-auto sm:h-9 md:h-10 lg:h-11 flex-shrink-0"
             aria-hidden="true"
           />
           <h1

--- a/src/index.css
+++ b/src/index.css
@@ -182,18 +182,21 @@
   }
 
   .brandLockup {
-    column-gap: 0.5em;
+    column-gap: 0.34em;
+    align-items: flex-end;
   }
 
   .brandMark {
     position: relative;
-    top: 1px;
+    top: 0;
+    display: block;
     image-rendering: -webkit-optimize-contrast;
   }
 
   .brandWordmark {
     display: inline-flex;
-    align-items: baseline;
+    align-items: flex-end;
+    transform: translateY(0.02em);
     font-kerning: normal;
     font-feature-settings: "kern" 1, "liga" 1, "calt" 1;
     -webkit-font-smoothing: antialiased;
@@ -202,26 +205,26 @@
 
   .brandPrimary {
     display: inline-flex;
-    letter-spacing: 0.018em;
+    letter-spacing: -0.01em;
   }
 
   .brandSecondary {
     display: inline-flex;
-    letter-spacing: 0.04em;
+    letter-spacing: -0.01em;
   }
 
   .brandGap {
     display: inline-block;
-    width: 0.28em;
+    width: 0.16em;
   }
 
   @media (max-width: 640px) {
     .brandLockup {
-      column-gap: 0.36em;
+      column-gap: 0.26em;
     }
 
     .brandGap {
-      width: 0.22em;
+      width: 0.12em;
     }
   }
 


### PR DESCRIPTION
### Motivation
- The dragon icon appeared slightly offset from the wordmark baseline and needed a precise tweak so the bottom of the logo aligns clearly with the bottom of the text.
- Small typographic and spacing refinements were required so the lockup reads as a single, balanced brand element across breakpoints.

### Description
- Adjusted header layout and spacing by switching the content row to bottom-aligned and setting explicit top/bottom paddings in `src/components/Header.jsx` so the lockup sits on the header baseline.
- Aligned lockup elements by changing `.brandLockup` and `.brandWordmark` to `align-items: flex-end`, removed the icon upward nudge, and applied a subtle `transform: translateY(0.02em)` to the wordmark in `src/index.css` so the icon bottom and text baseline line up.
- Increased the dragon image heights in `src/components/Header.jsx` and tightened `column-gap`, `brandGap`, and letter-spacing values in `src/index.css` to preserve rhythm and tighten the mark without changing visual scale.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` which launched successfully for visual verification.
- Captured a full-page Playwright screenshot at `artifacts/header-lockup.png` to confirm baseline alignment, and the capture completed successfully.
- No automated unit tests were added since these are visual/CSS adjustments validated via the screenshot.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698372a5eb308324a50840f059260e48)