### PR TITLE
Remove answer-mode instruction text from PracticeCard views

### DIFF
--- a/src/components/PracticeCard.jsx
+++ b/src/components/PracticeCard.jsx
@@ -331,9 +331,6 @@ export default function PracticeCard({
   const hearLabel = (t("hear") || "Hear").trim();
   const loadingLabel = (t("loading") || "Loading...").trim();
   const placeholder = t("placeholderType") || "Type the mutated form...";
-  const instructionText = `${t("inputMode") || "Answer mode"}: ${
-    answerMode === "tap" ? t("tapMode") || "Tap" : t("typeMode") || "Type"
-  }`;
 
   const choices = useMemo(() => {
     if (!sent) return [];
@@ -371,7 +368,6 @@ export default function PracticeCard({
                 t={t}
                 tooltipTranslate={tooltipTranslate}
                 tooltipWordCategory={wordCategory}
-                instructionText={instructionText}
                 guess={guess}
               />
             ) : (
@@ -395,7 +391,6 @@ export default function PracticeCard({
                 t={t}
                 tooltipTranslate={tooltipTranslate}
                 tooltipWordCategory={wordCategory}
-                instructionText={instructionText}
               />
             )}
           </div>

--- a/src/components/PracticeCardChoices.jsx
+++ b/src/components/PracticeCardChoices.jsx
@@ -36,7 +36,6 @@ export default function PracticeCardChoices({
   t,
   tooltipTranslate,
   tooltipWordCategory,
-  instructionText,
   guess,
 }) {
   const isFeedback = cardState === "feedback";
@@ -89,10 +88,6 @@ export default function PracticeCardChoices({
 
   return (
     <div className="space-y-6">
-      {instructionText ? (
-        <div className="text-sm text-muted-foreground">{instructionText}</div>
-      ) : null}
-
       <div className="flex justify-center w-full px-2">
         <div className="relative inline-flex max-w-full">
           <Badge

--- a/src/components/PracticeCardFront.jsx
+++ b/src/components/PracticeCardFront.jsx
@@ -31,7 +31,6 @@ export default function PracticeCardFront({
   t,
   tooltipTranslate,
   tooltipWordCategory,
-  instructionText,
 }) {
   const isFeedback = cardState === "feedback";
   const baseword = sent?.base || "_____";
@@ -56,10 +55,6 @@ export default function PracticeCardFront({
 
   return (
     <div className="space-y-6">
-      {instructionText ? (
-        <div className="text-sm text-muted-foreground">{instructionText}</div>
-      ) : null}
-
       <div className="flex justify-center w-full px-2">
         <div className="relative inline-flex max-w-full">
           {/* TODO: Map cardState or parent feedback state to HeroPill state (success/destructive/hint) */}


### PR DESCRIPTION
### Motivation
- The answer-mode instruction text (`t("inputMode") / "Answer mode"`) should no longer be composed or shown on practice cards to simplify the UI while preserving existing layouts.

### Description
- Stop composing the `instructionText` string in `src/components/PracticeCard.jsx` and stop passing it to the child views `PracticeCardFront` and `PracticeCardChoices`.
- Remove the small muted instruction text block from `PracticeCardFront` by deleting the `instructionText` prop and its rendering block.
- Remove the small muted instruction text block from `PracticeCardChoices` by deleting the `instructionText` prop and its rendering block.
- Kept all other props and layout intact so the card functionality and styling remain unchanged.

### Testing
- Started the dev server with `npm run dev` and confirmed the app served successfully on the local port; the server start completed without errors.
- Ran a Playwright script to load the app and capture a screenshot (`artifacts/practice-card-no-instruction.png`) which verified the instruction text is no longer displayed; the navigation and screenshot step succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69837f8085748324b3a732e7514ec69b)