### PR TITLE
Tighten header logo spacing and add mobile language dropdown

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,8 +1,14 @@
 import React from "react";
 import { useI18n } from "../i18n/I18nContext";
-import { Filter } from "lucide-react";
+import { Check, Filter, Globe } from "lucide-react";
 import AppIcon from "./icons/AppIcon";
 import { Button } from "./ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "./ui/dropdown-menu";
 import { Switch } from "./ui/switch";
 import {
   Tooltip,
@@ -31,7 +37,7 @@ export default function Header({
             aria-hidden="true"
           />
           <h1
-            className="text-2xl sm:text-3xl lg:text-4xl xl:text-5xl uppercase leading-none whitespace-nowrap"
+            className="-ml-1 sm:-ml-2 text-2xl sm:text-3xl lg:text-4xl xl:text-5xl uppercase leading-none whitespace-nowrap"
             style={{
               fontFamily:
                 "'BBH Bogle', 'bbh-bogle-regular', 'Bogle', 'Poppins', 'Inter', sans-serif",
@@ -55,7 +61,48 @@ export default function Header({
           <div className="flex items-center border border-border rounded-lg bg-[hsl(var(--rail))] px-2 py-1.5 sm:px-3 sm:py-2 gap-2 sm:gap-3 flex-shrink-0">
             
             {/* Language toggle: EN [switch] CY */}
-            <div className="hidden min-[400px]:flex items-center gap-1.5 sm:gap-2">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="sm:hidden h-8 w-8 text-primary hover:bg-[hsl(var(--rail))]/70"
+                  aria-label={t("headerSwitchLang") || "Toggle language"}
+                >
+                  <AppIcon icon={Globe} className="h-4 w-4" aria-hidden="true" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="min-w-[160px]">
+                <DropdownMenuItem
+                  className={cn("text-xs", !isCy && "text-primary")}
+                  onSelect={() => setLang("en")}
+                >
+                  English (EN)
+                  {!isCy ? (
+                    <AppIcon
+                      icon={Check}
+                      className="ml-auto h-3 w-3 text-primary"
+                      aria-hidden="true"
+                    />
+                  ) : null}
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  className={cn("text-xs", isCy && "text-primary")}
+                  onSelect={() => setLang("cy")}
+                >
+                  Cymraeg (CY)
+                  {isCy ? (
+                    <AppIcon
+                      icon={Check}
+                      className="ml-auto h-3 w-3 text-primary"
+                      aria-hidden="true"
+                    />
+                  ) : null}
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+
+            <div className="hidden sm:flex items-center gap-1.5 sm:gap-2">
               <span className={cn(
                 "text-[10px] sm:text-xs font-medium transition-colors",
                 !isCy ? "text-primary" : "text-muted-foreground"
@@ -77,7 +124,7 @@ export default function Header({
             </div>
 
             {/* Separator */}
-            <div className="hidden min-[400px]:block h-4 w-px bg-border" />
+            <div className="hidden sm:block h-4 w-px bg-border" />
 
             {/* Mobile filters button */}
             <Tooltip>

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,157 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+type DropdownMenuContextValue = {
+  open: boolean
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>
+  menuRef: React.RefObject<HTMLDivElement>
+}
+
+const DropdownMenuContext = React.createContext<DropdownMenuContextValue | null>(
+  null
+)
+
+const useDropdownMenu = () => {
+  const context = React.useContext(DropdownMenuContext)
+  if (!context) {
+    throw new Error("DropdownMenu components must be used within <DropdownMenu>")
+  }
+  return context
+}
+
+const DropdownMenu = ({ children }: { children: React.ReactNode }) => {
+  const [open, setOpen] = React.useState(false)
+  const menuRef = React.useRef<HTMLDivElement>(null)
+
+  React.useEffect(() => {
+    if (!open) {
+      return
+    }
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!menuRef.current?.contains(event.target as Node)) {
+        setOpen(false)
+      }
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setOpen(false)
+      }
+    }
+
+    document.addEventListener("pointerdown", handlePointerDown)
+    document.addEventListener("keydown", handleKeyDown)
+
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown)
+      document.removeEventListener("keydown", handleKeyDown)
+    }
+  }, [open])
+
+  return (
+    <DropdownMenuContext.Provider value={{ open, setOpen, menuRef }}>
+      <div className="relative inline-flex" ref={menuRef}>
+        {children}
+      </div>
+    </DropdownMenuContext.Provider>
+  )
+}
+
+const DropdownMenuTrigger = ({
+  asChild,
+  children,
+  ...props
+}: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  asChild?: boolean
+  children: React.ReactElement
+}) => {
+  const { open, setOpen } = useDropdownMenu()
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    children.props.onClick?.(event)
+    setOpen(!open)
+  }
+
+  if (asChild && React.isValidElement(children)) {
+    return React.cloneElement(children, {
+      ...props,
+      onClick: handleClick,
+      "aria-expanded": open,
+      "aria-haspopup": "menu",
+    })
+  }
+
+  return (
+    <button
+      type="button"
+      {...props}
+      onClick={handleClick}
+      aria-expanded={open}
+      aria-haspopup="menu"
+    >
+      {children}
+    </button>
+  )
+}
+
+const DropdownMenuContent = ({
+  align = "start",
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement> & { align?: "start" | "end" }) => {
+  const { open } = useDropdownMenu()
+
+  if (!open) {
+    return null
+  }
+
+  return (
+    <div
+      role="menu"
+      className={cn(
+        "absolute z-50 mt-2 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
+        align === "end" ? "right-0" : "left-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const DropdownMenuItem = ({
+  className,
+  onSelect,
+  ...props
+}: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  onSelect?: () => void
+}) => {
+  const { setOpen } = useDropdownMenu()
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    props.onClick?.(event)
+    onSelect?.()
+    setOpen(false)
+  }
+
+  return (
+    <button
+      type="button"
+      role="menuitem"
+      className={cn(
+        "flex w-full cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground disabled:pointer-events-none disabled:opacity-50",
+        className
+      )}
+      {...props}
+      onClick={handleClick}
+    />
+  )
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+}


### PR DESCRIPTION
### Motivation
- Bring the wordmark slightly left so the dragon mark visually sits closer to the “H” for a tighter logo/brand lockup.
- Provide a compact mobile language selector so language switching is accessible on small screens without altering the desktop experience.

### Description
- Updated `src/components/Header.jsx` to add a negative left margin on the wordmark (`h1`) to tighten spacing with the dragon mark and to import `Check` and `Globe` icons for the mobile control.
- Introduced a mobile `DropdownMenu`-based language selector in `src/components/Header.jsx` that shows a compact trigger and two `DropdownMenuItem` entries which mark the active language with a `Check` icon while preserving the existing desktop `Switch` control.
- Adjusted a minor breakpoint class on the separator from `min-[400px]` to `sm` to align with the new mobile behavior.
- Added a new lightweight dropdown implementation in `src/components/ui/dropdown-menu.tsx` exporting `DropdownMenu`, `DropdownMenuTrigger`, `DropdownMenuContent`, and `DropdownMenuItem` used by the header.

### Testing
- Started the dev server with `npm run dev` which launched successfully and served the app at the local dev URL.
- Attempted automated visual checks with Playwright to capture mobile and desktop screenshots, but the Playwright browser failed to launch in this environment and the screenshot step did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983834b0aac8324a4cfb3e72d0fd00a)