### PR TITLE
Remove emoji from English feedback strings

### DIFF
--- a/src/i18n/strings.js
+++ b/src/i18n/strings.js
@@ -106,8 +106,8 @@ export const STRINGS = {
 
     noCards: "No cards available. Check your filters/preset.",
 
-    correct: "✅ Correct",
-    notQuite: "❌ Not quite",
+    correct: "Correct",
+    notQuite: "Not quite",
     expected: "Expected",
 
     showDebug: "Show debug",


### PR DESCRIPTION
### Motivation
- Remove emoji prefixes from the English feedback strings so the feedback header can rely on the Lucide icon and avoid duplicate iconography.

### Description
- Replaced `correct: "✅ Correct"` and `notQuite: "❌ Not quite"` with `correct: "Correct"` and `notQuite: "Not quite"` in `src/i18n/strings.js`, and verified there are no other localized string entries with those emoji although hard-coded emoji remain in `src/components/TrainerCard.jsx`.

### Testing
- Ran repository searches (`rg "✅|❌"`) and inspected `src/i18n/strings.js` with `sed`, applied the patch and committed the change; all commands completed successfully and no automated test suite was run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69848c1f472c832495375aae2881501b)