### PR TITLE
Use extra-small shadcn-style hear Button for practice feedback

### DIFF
--- a/src/components/PracticeCardFeedback.jsx
+++ b/src/components/PracticeCardFeedback.jsx
@@ -1,7 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "./ui/button";
-import { ToggleGroup, ToggleGroupItem } from "./ui/toggle-group";
-import { Badge } from "./ui/badge";
 import { Card, CardContent } from "./ui/card";
 import { cn } from "../lib/cn";
 import {
@@ -62,6 +60,7 @@ export default function PracticeCardFeedback({
     return "";
   }, [last, t]);
   const isCorrect = last === "correct";
+  const hearButtonVariant = isCorrect ? "success" : "secondary";
   const nextLabel = t("next") || "Next";
   const statusIcon = useMemo(() => {
     if (!last) return null;
@@ -108,17 +107,15 @@ export default function PracticeCardFeedback({
             </p>
 
             <div className="flex flex-wrap items-center gap-3">
-              <Badge
-                variant="destructive"
-                className="cursor-pointer gap-1.5 rounded-full px-3 py-1.5"
+              <Button
+                type="button"
+                size="xs"
+                variant={hearButtonVariant}
                 onClick={onHear}
-                role="button"
-                tabIndex={0}
-                onKeyDown={(e) => e.key === "Enter" && onHear?.()}
               >
                 <AppIcon icon={Volume2} className="h-3.5 w-3.5" aria-hidden="true" />
                 {ttsLoading ? loadingLabel : hearLabel}
-              </Badge>
+              </Button>
 
               <label className="flex items-center gap-2 cursor-pointer text-sm text-muted-foreground">
                 <input

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -14,6 +14,8 @@ const badgeVariants = cva(
           "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
         destructive:
           "border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/90",
+        success:
+          "border-transparent bg-[hsl(var(--success)/0.15)] text-[hsl(var(--success))] hover:bg-[hsl(var(--success)/0.25)]",
         soft:
           "border-secondary/30 bg-secondary/15 text-foreground hover:bg-secondary/25",
         outline:

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -13,6 +13,8 @@ const buttonVariants = cva(
           "bg-primary text-primary-foreground shadow hover:bg-primary/90",
         destructive:
           "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
+        success:
+          "bg-[hsl(var(--success)/0.15)] text-[hsl(var(--success))] hover:bg-[hsl(var(--success)/0.25)]",
         outline:
           "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
         "outline-secondary":
@@ -28,6 +30,7 @@ const buttonVariants = cva(
       },
       size: {
         default: "h-9 px-4 py-2",
+        xs: "h-7 rounded-md px-2 text-xs",
         sm: "h-8 rounded-md px-3 text-xs",
         lg: "h-10 rounded-md px-8",
         icon: "h-9 w-9",


### PR DESCRIPTION
### Motivation
- Make the hear control conform to the shadcn extra-small button style and use a non-destructive success appearance when the last answer is correct.
- Replace the previous audio badge control with an accessible button so it behaves like other actionable controls.

### Description
- Add a `success` variant and an `xs` size to `src/components/ui/button.tsx` so buttons can render the low-opacity success styling and extra-small dimensions.
- Add a matching `success` variant to `src/components/ui/badge.tsx` (keeps parity) and remove the use of the old `Badge` for the hear action.
- Replace the hear `Badge` with a `Button` in `src/components/PracticeCardFeedback.jsx`, using `size="xs"` and `variant` set to `success` when `last === "correct"` or `secondary` otherwise, and remove the unused `ToggleGroup`/`Badge` imports.

### Testing
- Started the dev server with `npm run dev` and the site served at the dev URL successfully.
- Ran an automated Playwright script that loaded the app and saved a screenshot as `artifacts/practice-card-feedback-xs-button.png`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698494b99f6083249269b41f4b0129c4)