### PR TITLE
Adjust filter pill colors to use Cymru green tones

### DIFF
--- a/src/components/FiltersPanel.jsx
+++ b/src/components/FiltersPanel.jsx
@@ -215,6 +215,7 @@ export default function FiltersPanel({
                   <FilterBadge
                     active={isFamilyAll}
                     onClick={() => onClearFilterType?.("families")}
+                    className="bg-[hsl(var(--cymru-green))] text-[hsl(var(--cymru-white))] hover:bg-[hsl(var(--cymru-green)/0.9)]"
                   >
                     {t("filtersAll")}
                   </FilterBadge>
@@ -223,6 +224,7 @@ export default function FiltersPanel({
                       key={item.id}
                       active={safeFilters.families.has(item.id)}
                       onClick={() => onToggleFilter?.("families", item.id)}
+                      className="border-[hsl(var(--cymru-green)/0.2)] bg-[hsl(var(--cymru-green-wash))] text-[hsl(var(--cymru-green))] hover:bg-[hsl(var(--cymru-green-wash)/0.85)]"
                     >
                       {labelFor(item)}
                     </FilterBadge>
@@ -246,6 +248,7 @@ export default function FiltersPanel({
                   <FilterBadge
                     active={isCategoryAll}
                     onClick={() => onClearFilterType?.("categories")}
+                    className="bg-[hsl(var(--cymru-green-light))] text-[hsl(var(--cymru-text))] hover:bg-[hsl(var(--cymru-green-light)/0.9)]"
                   >
                     {t("filtersAll")}
                   </FilterBadge>


### PR DESCRIPTION
### Motivation
- Make the mutation-type and category filter pills visually distinct by using the existing Cymru green tokens (dark, washed, and light) without adding new colors or changing architecture.

### Description
- Update `src/components/FiltersPanel.jsx` to add Tailwind/HSL class names to the mutation-type "All" pill (dark Cymru green), the individual mutation-type pills (washed/muted Cymru dark green), and the category "All" pill (Cymru light green), reusing existing CSS variables like `--cymru-green`, `--cymru-green-wash`, and `--cymru-green-light`.

### Testing
- Ran the dev server with `npm run dev` and captured a UI screenshot using a Playwright script (`artifacts/filters-pills.png`), and both steps completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69853d08d3f4832495d318587fd91ce2)