### PR TITLE
Use shadcn `action` size and icons for practice action buttons

### DIFF
--- a/src/components/FlashcardArea.jsx
+++ b/src/components/FlashcardArea.jsx
@@ -37,7 +37,7 @@ export default function FlashcardArea({
                 type="single"
                 value={mode}
                 onValueChange={(value) => value && onModeChange(value)}
-                className="flex flex-wrap items-center gap-1 rounded-lg border border-border bg-card p-1 sm:flex-nowrap"
+                className="flex items-center gap-1 rounded-lg border border-border bg-card p-1 sm:flex-nowrap"
               >
                 <ToggleGroupItem
                   value="random"
@@ -63,7 +63,7 @@ export default function FlashcardArea({
                   type="single"
                   value={answerMode}
                   onValueChange={(value) => value && onAnswerModeChange(value)}
-                  className="flex flex-wrap items-center gap-1 rounded-lg border border-border bg-card p-1 sm:flex-nowrap"
+                  className="flex items-center gap-1 rounded-lg border border-border bg-card p-1 sm:flex-nowrap"
                 >
                   <ToggleGroupItem
                     value="type"

--- a/src/components/PracticeCard.jsx
+++ b/src/components/PracticeCard.jsx
@@ -209,10 +209,9 @@ function makeChoices(currentRow, deckRows, sent) {
 export default function PracticeCard({
   row,
   onResult,
-  mode,
+  mode = "random",
   answerMode = "type",
   deckRows = [],
-  mode = "random",
 }) {
   const { t, lang } = useI18n();
 
@@ -284,7 +283,7 @@ export default function PracticeCard({
     [answer, cardId, goNext, guess, isFeedback, mode, onResult, row]
   );
 
-  const onRevealOrSkip = () => {
+  const onReveal = () => {
     if (isFeedback) return;
 
     setCardState(CARD_STATES.FEEDBACK);
@@ -299,12 +298,8 @@ export default function PracticeCard({
 
   const onSkip = () => {
     if (isFeedback) return;
-
-    setCardState(CARD_STATES.FEEDBACK);
-    setLast("skipped");
     if (mode === "smart") {
-      setPendingResult("skipped");
-      setPendingReviewId(`${cardId}-${Date.now()}`);
+      onResult?.({ result: "skipped" });
       return;
     }
     onResult?.({ result: "skipped", guess: "", expected: answer });
@@ -391,7 +386,8 @@ export default function PracticeCard({
                 onToggleHint={() => setShowHint((s) => !s)}
                 onPick={(option) => onCheck(option)}
                 onCheck={onCheck}
-                onRevealOrSkip={onRevealOrSkip}
+                onReveal={onReveal}
+                onSkip={onSkip}
                 t={t}
                 tooltipTranslate={tooltipTranslate}
                 tooltipWordCategory={wordCategory}
@@ -412,7 +408,8 @@ export default function PracticeCard({
                 showHint={showHint}
                 onToggleHint={() => setShowHint((s) => !s)}
                 onCheck={onCheck}
-                onRevealOrSkip={onRevealOrSkip}
+                onReveal={onReveal}
+                onSkip={onSkip}
                 t={t}
                 tooltipTranslate={tooltipTranslate}
                 tooltipWordCategory={wordCategory}

--- a/src/components/PracticeCardChoices.jsx
+++ b/src/components/PracticeCardChoices.jsx
@@ -8,7 +8,7 @@ import {
   HoverCardContent,
   HoverCardTrigger,
 } from "./ui/hover-card";
-import { CheckCircle2, Lightbulb, MonitorPlay } from "lucide-react";
+import { CheckCircle2, Lightbulb, MonitorPlay, SkipForward } from "lucide-react";
 import AppIcon from "./icons/AppIcon";
 
 function normalizeChoice(value) {
@@ -31,7 +31,8 @@ export default function PracticeCardChoices({
   onToggleHint,
   onPick,
   onCheck,
-  onRevealOrSkip,
+  onReveal,
+  onSkip,
   t,
   tooltipTranslate,
   tooltipWordCategory,
@@ -79,8 +80,6 @@ export default function PracticeCardChoices({
   const hintLabel = t("hint") || "Hint";
   const revealLabel = t("reveal") || "Reveal";
   const skipLabel = t("skip") || "Skip";
-  const revealSkipLabel = `${revealLabel} / ${skipLabel}`;
-  const actionButtonSize = "lg";
 
   const normalizedAnswer = normalizeChoice(answer);
   const normalizedGuess = normalizeChoice(guess);
@@ -193,7 +192,7 @@ export default function PracticeCardChoices({
           type="button"
           variant="default"
           onClick={onCheck}
-          size={actionButtonSize}
+          size="action"
           className="flex-1 sm:flex-none min-w-[120px]"
         >
           <AppIcon icon={CheckCircle2} className="h-4 w-4" aria-hidden="true" />
@@ -204,7 +203,7 @@ export default function PracticeCardChoices({
           type="button"
           variant="outline-secondary"
           onClick={onToggleHint}
-          size={actionButtonSize}
+          size="action"
           className="flex-1 sm:flex-none min-w-[120px]"
         >
           <AppIcon icon={Lightbulb} className="h-4 w-4" aria-hidden="true" />
@@ -214,13 +213,25 @@ export default function PracticeCardChoices({
         <Button
           type="button"
           variant="ghost"
-          onClick={onRevealOrSkip}
+          onClick={onReveal}
           disabled={isFeedback}
-          size={actionButtonSize}
+          size="action"
           className="flex-1 sm:flex-none min-w-[120px]"
         >
           <AppIcon icon={MonitorPlay} className="h-4 w-4" aria-hidden="true" />
-          {revealSkipLabel}
+          {revealLabel}
+        </Button>
+
+        <Button
+          type="button"
+          variant="outline-accent"
+          onClick={onSkip}
+          disabled={isFeedback}
+          size="action"
+          className="flex-1 sm:flex-none min-w-[120px]"
+        >
+          <AppIcon icon={SkipForward} className="h-4 w-4" aria-hidden="true" />
+          {skipLabel}
         </Button>
       </div>
 

--- a/src/components/PracticeCardFeedback.jsx
+++ b/src/components/PracticeCardFeedback.jsx
@@ -84,8 +84,6 @@ export default function PracticeCardFeedback({
   );
   const isSmartMode = mode === "smart";
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const againLabel = t("again") || "Again";
-  const easyLabel = t("easy") || "Easy";
 
   const handleSmartResult = (result) => {
     if (!onResult || isSubmitting) return;
@@ -129,7 +127,7 @@ export default function PracticeCardFeedback({
             <div className="flex flex-wrap items-center gap-3">
               <Button
                 type="button"
-                size="xs"
+                size="action"
                 variant={hearButtonVariant}
                 onClick={onHear}
               >
@@ -177,15 +175,16 @@ export default function PracticeCardFeedback({
                   type="button"
                   variant="outline-secondary"
                   onClick={() => handleSmartResult("again")}
-                  size="lg"
+                  size="action"
                   disabled={isSubmitting}
                 >
+                  <AppIcon icon={Undo2} className="h-4 w-4" aria-hidden="true" />
                   {againLabel}
                 </Button>
                 <Button
                   type="button"
                   onClick={() => handleSmartResult("next")}
-                  size="lg"
+                  size="action"
                   disabled={isSubmitting}
                 >
                   {nextLabel}
@@ -195,14 +194,15 @@ export default function PracticeCardFeedback({
                   type="button"
                   variant="success"
                   onClick={() => handleSmartResult("easy")}
-                  size="lg"
+                  size="action"
                   disabled={isSubmitting}
                 >
+                  <AppIcon icon={CheckCircle2} className="h-4 w-4" aria-hidden="true" />
                   {easyLabel}
                 </Button>
               </>
             ) : (
-              <Button type="button" onClick={onNext} size="lg">
+              <Button type="button" onClick={onNext} size="action">
                 {nextLabel}
                 <AppIcon icon={ArrowRight} className="h-5 w-5" aria-hidden="true" />
               </Button>

--- a/src/components/PracticeCardFront.jsx
+++ b/src/components/PracticeCardFront.jsx
@@ -10,7 +10,7 @@ import {
   HoverCardContent,
   HoverCardTrigger,
 } from "./ui/hover-card";
-import { CheckCircle2, Lightbulb, MonitorPlay } from "lucide-react";
+import { CheckCircle2, Lightbulb, MonitorPlay, SkipForward } from "lucide-react";
 import AppIcon from "./icons/AppIcon";
 
 export default function PracticeCardFront({
@@ -26,7 +26,8 @@ export default function PracticeCardFront({
   showHint,
   onToggleHint,
   onCheck,
-  onRevealOrSkip,
+  onReveal,
+  onSkip,
   t,
   tooltipTranslate,
   tooltipWordCategory,
@@ -51,7 +52,6 @@ export default function PracticeCardFront({
   const hintLabel = t("hint") || "Hint";
   const revealLabel = t("reveal") || "Reveal";
   const skipLabel = t("skip") || "Skip";
-  const revealSkipLabel = `${revealLabel} / ${skipLabel}`;
 
   return (
     <div className="space-y-6">
@@ -149,12 +149,24 @@ export default function PracticeCardFront({
       <Separator />
 
       <div className="flex flex-wrap items-center gap-2 justify-center sm:justify-start">
-        <Button type="button" variant="default" onClick={onCheck} className="flex-1 sm:flex-none min-w-[120px]">
+        <Button
+          type="button"
+          variant="default"
+          onClick={onCheck}
+          size="action"
+          className="flex-1 sm:flex-none min-w-[120px]"
+        >
           <AppIcon icon={CheckCircle2} className="h-4 w-4" aria-hidden="true" />
           {checkLabel}
         </Button>
 
-        <Button type="button" variant="outline-secondary" onClick={onToggleHint} className="flex-1 sm:flex-none min-w-[120px]">
+        <Button
+          type="button"
+          variant="outline-secondary"
+          onClick={onToggleHint}
+          size="action"
+          className="flex-1 sm:flex-none min-w-[120px]"
+        >
           <AppIcon icon={Lightbulb} className="h-4 w-4" aria-hidden="true" />
           {hintLabel}
         </Button>
@@ -162,12 +174,25 @@ export default function PracticeCardFront({
         <Button
           type="button"
           variant="ghost"
-          onClick={onRevealOrSkip}
+          onClick={onReveal}
           disabled={isFeedback}
+          size="action"
           className="flex-1 sm:flex-none min-w-[120px]"
         >
           <AppIcon icon={MonitorPlay} className="h-4 w-4" aria-hidden="true" />
-          {revealSkipLabel}
+          {revealLabel}
+        </Button>
+
+        <Button
+          type="button"
+          variant="outline-accent"
+          onClick={onSkip}
+          disabled={isFeedback}
+          size="action"
+          className="flex-1 sm:flex-none min-w-[120px]"
+        >
+          <AppIcon icon={SkipForward} className="h-4 w-4" aria-hidden="true" />
+          {skipLabel}
         </Button>
       </div>
 

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -30,6 +30,7 @@ const buttonVariants = cva(
       },
       size: {
         default: "h-9 px-4 py-2",
+        action: "h-7 px-2 py-1 text-xs sm:h-9 sm:px-4 sm:py-2 sm:text-sm",
         xs: "h-7 rounded-md px-2 text-xs",
         sm: "h-8 rounded-md px-3 text-xs",
         lg: "h-10 rounded-md px-8",


### PR DESCRIPTION
### Motivation
- Standardize sizing and visuals for all practice action buttons by using the shared shadcn `action` size token and the button+icon pattern so action rows look consistent across views. 
- Make the Skip action use the gold/shadcn accent style so it visually matches the intended emphasis.

### Description
- Added the `action` size token in `src/components/ui/button.tsx` and applied it to practice action buttons to replace scattered ad-hoc sizing. 
- Updated `PracticeCardFront.jsx`, `PracticeCardChoices.jsx`, and `PracticeCardFeedback.jsx` to use `size="action"` and to render icons via `AppIcon` for Check/Hint/Reveal/Skip/Again/Easy/Next so every action button follows the shadcn button+icon pattern. 
- Switched the Skip button variant to `outline-accent` (gold) and adjusted reveal/skip behavior by splitting `onRevealOrSkip` into separate `onReveal` and `onSkip` handlers wired through `PracticeCard.jsx`.

### Testing
- Ran the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and Vite started successfully. ✅
- Attempted to capture a mobile viewport screenshot with Playwright but the run crashed with a SIGSEGV in this environment, so no screenshot was produced. ❌

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698613aa32ac8324944c161300a0caf6)