### PR TITLE
Wrap Quick packs and Core filters accordion titles in light Cymru green badges

### DIFF
--- a/src/components/FiltersPanel.jsx
+++ b/src/components/FiltersPanel.jsx
@@ -94,16 +94,14 @@ export default function FiltersPanel({
       <Accordion className="w-full" collapsible defaultValue="item-start" type="single">
         <AccordionItem value="item-start">
           <AccordionTrigger>
-            <div className="flex items-center gap-3">
+            <Badge className="gap-2 rounded-full bg-[hsl(var(--cymru-green))] px-4 py-1.5 text-sm font-semibold text-white">
               <AppIcon
                 icon={HelpCircle}
-                className="h-5 w-5 text-primary"
+                className="h-5 w-5 text-white"
                 aria-hidden="true"
               />
-              <span className="text-base font-bold text-foreground">
-                {t("startHereTitle")}
-              </span>
-            </div>
+              <span>{t("startHereTitle")}</span>
+            </Badge>
           </AccordionTrigger>
           <AccordionContent>
             <GlassPanel className="p-4 space-y-3">
@@ -124,28 +122,26 @@ export default function FiltersPanel({
 
         <AccordionItem value="item-quick">
           <AccordionTrigger>
-            <div className="flex items-center gap-3">
+            <Badge className="gap-2 rounded-full border border-[hsl(var(--cymru-green-light))] bg-[hsl(var(--cymru-green-wash))] px-3 py-1 text-xs font-semibold text-[hsl(var(--cymru-green))]">
               <AppIcon
                 icon={Zap}
-                className="h-5 w-5 text-primary"
+                className="h-4 w-4 text-[hsl(var(--cymru-green))]"
                 aria-hidden="true"
               />
-              <span className="text-base font-bold text-foreground">
-                {t("quickPacksTitle")}
-              </span>
-            </div>
+              <span>{t("quickPacksTitle")}</span>
+            </Badge>
           </AccordionTrigger>
           <AccordionContent>
-            <div className="mb-4">
-              <p className="text-sm text-muted-foreground">
+            <div className="mb-3">
+              <p className="text-xs text-muted-foreground">
                 {t("quickPacksSubtitle")}
               </p>
-              <p className="text-xs text-muted-foreground mt-1">
+              <p className="text-[0.7rem] text-muted-foreground mt-1">
                 {t("quickPacksHint")}
               </p>
             </div>
 
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
               {PRESET_ORDER.map((id) => {
                 const def = PRESET_DEFS[id];
                 const active = activePresetId === id;
@@ -187,20 +183,18 @@ export default function FiltersPanel({
 
         <AccordionItem value="item-core">
           <AccordionTrigger>
-            <div className="flex items-center gap-3">
+            <Badge className="gap-2 rounded-full border border-[hsl(var(--cymru-green-light))] bg-[hsl(var(--cymru-green-wash))] px-3 py-1 text-xs font-semibold text-[hsl(var(--cymru-green))]">
               <AppIcon
                 icon={Filter}
-                className="h-5 w-5 text-primary"
+                className="h-4 w-4 text-[hsl(var(--cymru-green))]"
                 aria-hidden="true"
               />
-              <span className="text-base font-bold text-foreground">
-                {t("coreFiltersTitle")}
-              </span>
-            </div>
+              <span>{t("coreFiltersTitle")}</span>
+            </Badge>
           </AccordionTrigger>
           <AccordionContent>
-            <div className="mb-4">
-              <p className="text-sm text-muted-foreground">
+            <div className="mb-3">
+              <p className="text-xs text-muted-foreground">
                 {t("coreFiltersSubtitle")}
               </p>
             </div>


### PR DESCRIPTION
### Motivation
- Make the Quick packs and Core filters accordion headings visually subordinate to the more prominent "Start here" pill by converting them to pill-style badges with a lighter Cymru green treatment.
- Tighten heading sizing and spacing in the Quick packs and Core filters sections so they read as secondary content under the Start here callout.

### Description
- Replaced the trigger content for the Quick packs and Core filters `AccordionTrigger` elements with `Badge` pills using `border-[hsl(var(--cymru-green-light))]`, `bg-[hsl(var(--cymru-green-wash))]` and `text-[hsl(var(--cymru-green))]` styling to create a light-outline + washed-fill appearance in `src/components/FiltersPanel.jsx`.
- Reduced icon sizes to `h-4 w-4`, changed badge text to `text-xs font-semibold`, and updated the Start here pill to use a solid green badge with white icon/text for prominence.
- Adjusted internal section spacing and typography: subtitles changed to `text-xs`, hints to `text-[0.7rem]`, grid gaps from `gap-3` to `gap-2`, and margins reduced from `mb-4` to `mb-3` where applicable.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and Vite reported ready and serving the app.
- Attempted an automated Playwright script to capture a screenshot, but Chromium failed to launch due to a `TargetClosedError` / SIGSEGV so the screenshot was not produced.
- No unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69862ae43c908324ace4d44572c11a5a)