### PR TITLE
Add practice helper, smart‑mode keyboard shortcuts, and input autofocus

### DIFF
--- a/src/components/FlashcardArea.jsx
+++ b/src/components/FlashcardArea.jsx
@@ -83,6 +83,8 @@ export default function FlashcardArea({
           </div>
         </div>
 
+        <p className="text-xs text-muted-foreground">{t("practiceHelper")}</p>
+
         <Separator />
 
         {!currentRow ? (

--- a/src/components/PracticeCard.jsx
+++ b/src/components/PracticeCard.jsx
@@ -318,6 +318,18 @@ export default function PracticeCard({
     }
   };
 
+  const handleSmartResult = useCallback(
+    (result) => {
+      if (mode !== "smart" || !isFeedback || !onResult) return;
+      onResult({
+        result,
+        baseResult: pendingResult,
+        reviewId: pendingReviewId,
+      });
+    },
+    [isFeedback, mode, onResult, pendingResult, pendingReviewId]
+  );
+
   // Keyboard navigation
   useEffect(() => {
     const handleKeyDown = (e) => {
@@ -325,6 +337,27 @@ export default function PracticeCard({
         e.target instanceof HTMLInputElement ||
         e.target instanceof HTMLTextAreaElement
       ) {
+        return;
+      }
+
+      const key = e.key.toLowerCase();
+
+      if (isFeedback && mode === "smart") {
+        if (key === "e") {
+          e.preventDefault();
+          handleSmartResult("easy");
+          return;
+        }
+        if (key === "a") {
+          e.preventDefault();
+          handleSmartResult("again");
+          return;
+        }
+      }
+
+      if (isFeedback && (key === "h" || key === "p")) {
+        e.preventDefault();
+        onHear();
         return;
       }
 
@@ -340,7 +373,7 @@ export default function PracticeCard({
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [goNext, isFeedback, onCheck, row]);
+  }, [goNext, handleSmartResult, isFeedback, mode, onCheck, onHear]);
 
   const whyEn = row?.why ?? row?.Why ?? "";
   const whyCy = row?.whyCym ?? row?.["Why-Cym"] ?? row?.WhyCym ?? "";
@@ -398,6 +431,7 @@ export default function PracticeCard({
                 sent={sent}
                 answer={answer}
                 cardState={cardState}
+                cardId={cardId}
                 guess={guess}
                 setGuess={setGuess}
                 disabledInput={disabledInput}

--- a/src/components/PracticeCardFront.jsx
+++ b/src/components/PracticeCardFront.jsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { Button } from "./ui/button";
 import { Badge } from "./ui/badge";
 import HeroPill from "./HeroPill";
@@ -16,6 +16,7 @@ import AppIcon from "./icons/AppIcon";
 export default function PracticeCardFront({
   sent,
   cardState,
+  cardId,
   guess,
   setGuess,
   disabledInput,
@@ -34,6 +35,7 @@ export default function PracticeCardFront({
 }) {
   const isFeedback = cardState === "feedback";
   const baseword = sent?.base || "_____";
+  const inputRef = useRef(null);
   const hoverCardContentClass =
     "w-64 max-w-[85vw] rounded-2xl border border-border bg-card/95 p-4 text-sm text-foreground shadow-xl backdrop-blur";
 
@@ -52,6 +54,11 @@ export default function PracticeCardFront({
   const hintLabel = t("hint") || "Hint";
   const revealLabel = t("reveal") || "Reveal";
   const skipLabel = t("skip") || "Skip";
+
+  useEffect(() => {
+    if (isFeedback) return;
+    inputRef.current?.focus();
+  }, [cardId, isFeedback]);
 
   return (
     <div className="space-y-6">
@@ -134,6 +141,7 @@ export default function PracticeCardFront({
       <div className="text-base sm:text-lg leading-relaxed text-foreground">
         <span className="whitespace-pre-wrap break-words">{sent?.before}</span>
         <Input
+          ref={inputRef}
           value={guess}
           onChange={(e) => setGuess(e.target.value)}
           disabled={disabledInput}

--- a/src/i18n/strings.js
+++ b/src/i18n/strings.js
@@ -23,6 +23,8 @@ export const STRINGS = {
     typeMode: "Teipio",
     tapMode: "Tapio",
     inputMode: "Dull ateb",
+    practiceHelper:
+      "Pwyswch Enter i wirio, yna defnyddiwch E/A i raddio yn y modd clyfar. Pwyswch H i glywed.",
 
     noCards: "Dim cardiau ar gael. Gwiriwch eich hidlwyr/pecyn.",
 
@@ -107,6 +109,8 @@ export const STRINGS = {
     typeMode: "Type",
     tapMode: "Tap",
     inputMode: "Answer mode",
+    practiceHelper:
+      "Press Enter to check, then use E/A to grade in smart mode. Press H to hear.",
 
     noCards: "No cards available. Check your filters/preset.",
 


### PR DESCRIPTION
### Motivation

- Improve discoverability of practice keyboard shortcuts and streamline grading during feedback in smart mode. 
- Make typing flow smoother by auto-focusing the answer input when a new card appears (unless feedback is shown).

### Description

- Add a muted helper line to the practice header in `FlashcardArea.jsx` and wire it to `t("practiceHelper")` with new i18n keys added to `src/i18n/strings.js` for both `en` and `cy`.
- Extend keyboard handling in `PracticeCard.jsx` by adding `handleSmartResult` and listening for `E`/`A` to grade (`easy`/`again`) when `mode === "smart"` and feedback is visible, and `H`/`P` to trigger `onHear` during feedback; the shortcuts are scoped to non-input targets and only active in the appropriate states.
- Pass `cardId` down to `PracticeCardFront` and add a `ref` + `useEffect` in `PracticeCardFront.jsx` to auto-focus the text `Input` whenever `cardId` changes and feedback is not active.

### Testing

- Started the dev server with `npm run dev` (Vite) which launched successfully and served the app. (succeeded)
- Ran a Playwright script to load the app page and capture a screenshot to validate the UI change (screenshot artifact produced), and the script completed successfully. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69863101a5648324a7ca4047866024ec)