### PR TITLE
Style feedback Hear control as Cymru light badge

### DIFF
--- a/src/components/PracticeCardFeedback.jsx
+++ b/src/components/PracticeCardFeedback.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "./ui/button";
 import { Card, CardContent } from "./ui/card";
+import { badgeVariants } from "./ui/badge";
 import { cn } from "../lib/cn";
 import {
   ArrowRight,
@@ -64,7 +65,7 @@ export default function PracticeCardFeedback({
     return "";
   }, [last, t]);
   const isCorrect = last === "correct";
-  const hearButtonVariant = isCorrect ? "success" : "secondary";
+  const hearButtonVariant = "cymru-light";
   const nextLabel = t("next") || "Next";
   const easyLabel = t("easy") || "Easy";
   const againLabel = t("again") || "Again";
@@ -125,15 +126,18 @@ export default function PracticeCardFeedback({
             </p>
 
             <div className="flex flex-wrap items-center gap-3">
-              <Button
+              <button
                 type="button"
-                size="action"
-                variant={hearButtonVariant}
                 onClick={onHear}
+                className={cn(
+                  badgeVariants({ variant: hearButtonVariant }),
+                  "cursor-pointer select-none rounded-full px-3 py-1 text-xs font-semibold transition-colors",
+                  "inline-flex items-center gap-1.5"
+                )}
               >
                 <AppIcon icon={Volume2} className="h-3.5 w-3.5" aria-hidden="true" />
                 {ttsLoading ? loadingLabel : hearLabel}
-              </Button>
+              </button>
 
               <label className="flex items-center gap-2 cursor-pointer text-sm text-muted-foreground">
                 <input


### PR DESCRIPTION
### Motivation
- Make the feedback card “Hear” control visually match the SHADCN small badge used for the categories "All" pill by using the same `cymru-light` styling (Cymru light green background with white text). 

### Description
- Import `badgeVariants` from `src/components/ui/badge` and set the hear control variant to `"cymru-light"`.
- Replace the `Button` component for the Hear control with a plain `button` that composes `badgeVariants({ variant: hearButtonVariant })` via `cn` and applies `inline-flex`/padding/text classes to match the pill appearance.
- Keep behavior intact (`onHear`, loading label, icon and autoplay checkbox remain unchanged).

### Testing
- Started the dev server with `npm run dev` and the app served successfully at the local URL.
- Ran an automated Playwright script that navigated to the app, revealed the feedback card, and saved a screenshot to `artifacts/feedback-hear-badge.png`, which completed successfully.
- No unit tests were added or run for this purely visual change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986328572888324b9ba62cfc8a4d4ae)