### PR TITLE
Refine FiltersPanel accordion header styling

### DIFF
--- a/src/components/FiltersPanel.jsx
+++ b/src/components/FiltersPanel.jsx
@@ -62,6 +62,8 @@ export default function FiltersPanel({
   const { t } = useI18n();
 
   const [expandedCats, setExpandedCats] = useState(false);
+  const headerBase = "inline-flex items-center gap-2 font-semibold";
+  const headerIcon = "h-4 w-4 shrink-0";
 
   const safeAvailable = available || { families: [], categories: [] };
   const safeFilters = filters || { families: new Set(), categories: new Set() };
@@ -94,10 +96,15 @@ export default function FiltersPanel({
       <Accordion className="w-full" collapsible defaultValue="item-start" type="single">
         <AccordionItem value="item-start">
           <AccordionTrigger>
-            <Badge className="gap-2 rounded-full bg-[hsl(var(--cymru-green))] px-4 py-1.5 text-sm font-semibold text-white">
+            <Badge
+              className={cn(
+                headerBase,
+                "rounded-full bg-[hsl(var(--cymru-green))] px-4 py-2 text-base text-white shadow-sm"
+              )}
+            >
               <AppIcon
                 icon={HelpCircle}
-                className="h-5 w-5 text-white"
+                className={cn(headerIcon, "text-white")}
                 aria-hidden="true"
               />
               <span>{t("startHereTitle")}</span>
@@ -122,13 +129,13 @@ export default function FiltersPanel({
 
         <AccordionItem value="item-quick">
           <AccordionTrigger>
-            <div className="flex items-center gap-2 text-[hsl(var(--cymru-green))]">
+            <div className={cn(headerBase, "text-sm text-[hsl(var(--cymru-green))]")}>
               <AppIcon
                 icon={Zap}
-                className="h-4 w-4 text-[hsl(var(--cymru-green))]"
+                className={cn(headerIcon, "text-[hsl(var(--cymru-green))]")}
                 aria-hidden="true"
               />
-              <span className="text-xs font-semibold">{t("quickPacksTitle")}</span>
+              <span>{t("quickPacksTitle")}</span>
             </div>
           </AccordionTrigger>
           <AccordionContent>
@@ -183,13 +190,13 @@ export default function FiltersPanel({
 
         <AccordionItem value="item-core">
           <AccordionTrigger>
-            <div className="flex items-center gap-2 text-[hsl(var(--cymru-green))]">
+            <div className={cn(headerBase, "text-sm text-[hsl(var(--cymru-green))]")}>
               <AppIcon
                 icon={Filter}
-                className="h-4 w-4 text-[hsl(var(--cymru-green))]"
+                className={cn(headerIcon, "text-[hsl(var(--cymru-green))]")}
                 aria-hidden="true"
               />
-              <span className="text-xs font-semibold">{t("coreFiltersTitle")}</span>
+              <span>{t("coreFiltersTitle")}</span>
             </div>
           </AccordionTrigger>
           <AccordionContent>


### PR DESCRIPTION
### Motivation
- Unify the accordion header layout so all headers share consistent icon sizing, spacing, and typography for a cleaner UI.
- Give the “Start here” header a slightly stronger visual treatment so it stands out while remaining stylistically consistent with other headers.
- Replace mixed small text sizes with a cohesive scale so header labels are aligned and balanced.

### Description
- Introduced shared header classes (`headerBase` and `headerIcon`) and applied them to all `AccordionTrigger` headers to standardize layout and spacing.
- Updated the `Start here` header badge to use a slightly larger scale (`text-base`, increased vertical padding) and a subtle `shadow-sm` for emphasis while keeping the same color scheme.
- Replaced individual `text-xs` usages in the accordion header labels with a consistent `text-sm`/`font-semibold` scale and moved typography into the shared `headerBase` string.
- Ensured all icons use the same `h-4 w-4 shrink-0` sizing and are inserted via `AppIcon` with consistent classes for baseline alignment.

### Testing
- Launched the dev server with `npm run dev` and verified the app served at the local URL successfully.
- Ran a Playwright script to open the page and capture a screenshot (`artifacts/filters-panel.png`) to validate the visual changes, and the script completed successfully.
- No automated unit tests were modified or required for this visual-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698637a616e48324b9ca4aa0ac7ba29a)