### PR TITLE
Adjust filter badge variants and behavior for mutation and category filters

### DIFF
--- a/src/components/FiltersPanel.jsx
+++ b/src/components/FiltersPanel.jsx
@@ -216,7 +216,7 @@ export default function FiltersPanel({
                   <FilterBadge
                     active={isFamilyAll}
                     onClick={() => onClearFilterType?.("families")}
-                    className="bg-[hsl(var(--cymru-green))] text-[hsl(var(--cymru-white))] hover:bg-[hsl(var(--cymru-green)/0.9)]"
+                    variant={isFamilyAll ? "cymru-dark" : "cymru-wash"}
                   >
                     {t("filtersAll")}
                   </FilterBadge>
@@ -225,7 +225,9 @@ export default function FiltersPanel({
                       key={item.id}
                       active={safeFilters.families.has(item.id)}
                       onClick={() => onToggleFilter?.("families", item.id)}
-                      className="border-[hsl(var(--cymru-green)/0.2)] bg-[hsl(var(--cymru-green-wash))] text-[hsl(var(--cymru-green))] hover:bg-[hsl(var(--cymru-green-wash)/0.85)]"
+                      variant={
+                        safeFilters.families.has(item.id) ? "cymru-dark" : "cymru-wash"
+                      }
                     >
                       {labelFor(item)}
                     </FilterBadge>
@@ -249,7 +251,7 @@ export default function FiltersPanel({
                   <FilterBadge
                     active={isCategoryAll}
                     onClick={() => onClearFilterType?.("categories")}
-                    variant="cymru-light"
+                    variant={isCategoryAll ? "cymru-light" : "cymru-wash"}
                   >
                     {t("filtersAll")}
                   </FilterBadge>
@@ -258,6 +260,11 @@ export default function FiltersPanel({
                       key={item.id}
                       active={safeFilters.categories.has(item.id)}
                       onClick={() => onToggleFilter?.("categories", item.id)}
+                      variant={
+                        safeFilters.categories.has(item.id)
+                          ? "cymru-light"
+                          : "cymru-wash"
+                      }
                     >
                       {labelFor(item)}
                     </FilterBadge>

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -22,6 +22,10 @@ const badgeVariants = cva(
           "border-border bg-transparent text-foreground hover:bg-secondary/15",
         "cymru-light":
           "border-transparent bg-[hsl(var(--cymru-green-light))] text-[hsl(var(--cymru-white))] hover:bg-[hsl(var(--cymru-green-light)/0.9)]",
+        "cymru-dark":
+          "border-transparent bg-[hsl(var(--cymru-green))] text-[hsl(var(--cymru-white))] hover:bg-[hsl(var(--cymru-green)/0.9)]",
+        "cymru-wash":
+          "border-[hsl(var(--cymru-green)/0.2)] bg-[hsl(var(--cymru-green-wash))] text-[hsl(var(--cymru-green))] hover:bg-[hsl(var(--cymru-green-wash)/0.85)]",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
### Motivation
- Ensure the filter badges follow the requested active/inactive color scheme and hover behavior using existing ShadCN `Badge` variants instead of ad-hoc classes.  
- Make the “All” badge visually active only when no filters are selected so it reflects filter state accurately.

### Description
- Added two new badge variants to `src/components/ui/badge.tsx`: `cymru-dark` (dark green with white text and hover) and `cymru-wash` (light/washed green with hover) so variants provide both base and hover styles.  
- Updated `src/components/FiltersPanel.jsx` to use the new variants and conditional logic: mutation-type badges use `cymru-dark` when active and `cymru-wash` when inactive; category badges use `cymru-light` for active and `cymru-wash` for inactive; the `All` badge now uses the active variant only when no filters are selected.  
- Kept usage of ShadCN `Badge`/`badgeVariants` and removed custom hardcoded hover colors where a variant exists so hover behavior is driven by the variant definitions.

### Testing
- Started the dev server with `npm run dev` and verified the app served successfully at the local dev URL. (success)  
- Captured a visual snapshot using a Playwright script visiting `http://127.0.0.1:4173/mutationtrainer-react/` and saving `artifacts/filters-panel.png` to validate visual changes. (success)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698638d41f1483249b0bcfb0e6345f6b)