### PR TITLE
Remove mobile header icon background; add mobile Help and controlled Filters accordion

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -25,6 +25,7 @@ export default function App() {
   const [currentIdx, setCurrentIdx] = useState(-1);
   const [sessionCardCount, setSessionCardCount] = useState(1); // Track cards viewed in session
   const [filtersOpen, setFiltersOpen] = useState(false);
+  const [filtersOpenItems, setFiltersOpenItems] = useState(["item-core", "item-quick"]);
   const [filters, setFilters] = useState({
     families: new Set(),
     categories: new Set(),
@@ -226,10 +227,16 @@ export default function App() {
     setFilters((prev) => ({ ...prev, [kind]: new Set() }));
   };
 
+  const openFiltersSheet = (items) => {
+    setFiltersOpenItems(items);
+    setFiltersOpen(true);
+  };
+
   return (
     <div className="min-h-full">
       <Header
-        onOpenFilters={() => setFiltersOpen(true)}
+        onOpenFilters={() => openFiltersSheet(["item-core", "item-quick"])}
+        onOpenHelp={() => openFiltersSheet(["item-start"])}
       />
 
       <main className="mx-auto w-full max-w-6xl px-4 py-4 sm:px-6">
@@ -270,6 +277,9 @@ export default function App() {
           filters={filters}
           onToggleFilter={toggleFilter}
           onClearFilterType={clearFilterType}
+          openItems={filtersOpenItems}
+          onOpenItemsChange={setFiltersOpenItems}
+          accordionType="multiple"
         />
       </FilterSheet>
     </div>

--- a/src/components/FiltersPanel.jsx
+++ b/src/components/FiltersPanel.jsx
@@ -58,6 +58,9 @@ export default function FiltersPanel({
   filters = { families: new Set(), categories: new Set() },
   onToggleFilter,
   onClearFilterType,
+  openItems,
+  onOpenItemsChange,
+  accordionType = "single",
 }) {
   const { t } = useI18n();
 
@@ -91,9 +94,19 @@ export default function FiltersPanel({
     return item.label ?? "";
   };
 
+  const accordionProps =
+    openItems !== undefined
+      ? { value: openItems, onValueChange: onOpenItemsChange }
+      : { defaultValue: "item-start" };
+
   return (
     <div className={cn("space-y-8 py-2 px-1", className)}>
-      <Accordion className="w-full" collapsible defaultValue="item-start" type="single">
+      <Accordion
+        className="w-full"
+        collapsible={accordionType === "single"}
+        type={accordionType}
+        {...accordionProps}
+      >
         <AccordionItem value="item-start">
           <AccordionTrigger>
             <Badge

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useI18n } from "../i18n/I18nContext";
-import { Check, Filter, Globe } from "lucide-react";
+import { Check, Filter, Globe, HelpCircle } from "lucide-react";
 import AppIcon from "./icons/AppIcon";
 import { Button } from "./ui/button";
 import {
@@ -20,6 +20,7 @@ import { cn } from "../lib/cn";
 
 export default function Header({
   onOpenFilters,
+  onOpenHelp,
 }) {
   const { lang, setLang, t } = useI18n();
   const isCy = lang === "cy";
@@ -58,7 +59,7 @@ export default function Header({
 
         {/* Control cluster: unified minimal surface */}
         <TooltipProvider>
-          <div className="flex items-center border border-border rounded-lg bg-[hsl(var(--rail))] px-2 py-1.5 sm:px-3 sm:py-2 gap-2 sm:gap-3 flex-shrink-0">
+          <div className="flex items-center self-center sm:border sm:border-border sm:rounded-lg sm:bg-[hsl(var(--rail))] px-0 py-0 sm:px-3 sm:py-2 gap-2 sm:gap-3 flex-shrink-0">
             
             {/* Language toggle: EN [switch] CY */}
             <DropdownMenu>
@@ -145,6 +146,28 @@ export default function Header({
               </TooltipTrigger>
               <TooltipContent side="bottom">
                 {t("headerFilters") || "Filters"}
+              </TooltipContent>
+            </Tooltip>
+
+            {/* Mobile help button */}
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="sm:hidden h-8 w-8 text-primary hover:bg-[hsl(var(--rail))]/70"
+                  onClick={onOpenHelp}
+                  aria-label={t("headerHelp") || "Help"}
+                >
+                  <AppIcon
+                    icon={HelpCircle}
+                    className="h-4 w-4"
+                    aria-hidden="true"
+                  />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                {t("headerHelp") || "Help"}
               </TooltipContent>
             </Tooltip>
           </div>


### PR DESCRIPTION
### Motivation
- Remove the grey background container on mobile so the header icon cluster sits flush and vertically aligned with the heading text. 
- Provide a mobile Help control next to the Filters button so users can access help on small screens. 
- Allow the filters sheet to control which accordion panels are open so the mobile sheet can open multiple useful sections simultaneously.

### Description
- Updated `src/components/Header.jsx` to scope the border/background/rounded styles to `sm:` so mobile no longer shows the grey rounded container, added `self-center` to better align the icon cluster, and added a mobile Help icon wired to `onOpenHelp` and the `HelpCircle` import. 
- Updated `src/components/FiltersPanel.jsx` to accept `openItems`, `onOpenItemsChange`, and `accordionType` props and to pass controlled props into the `Accordion` (`value`/`onValueChange` when controlled, otherwise `defaultValue`), and to make `collapsible` depend on `accordionType`. 
- Updated `src/App.jsx` to add `filtersOpenItems` state and an `openFiltersSheet(items)` helper, to expose `onOpenFilters` and `onOpenHelp` handlers that open the sheet with specific panels, and to pass `openItems`, `onOpenItemsChange`, and `accordionType="multiple"` into `FiltersPanel` when rendering inside `FilterSheet`.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173`, which launched successfully and served the app. 
- Ran a Playwright script that opened a 390×844 viewport and captured a mobile screenshot saved as `artifacts/mobile-header-help.png`, confirming the mobile header shows the Help and Filters icons aligned with the heading and without the grey background. 
- No unit test suite was executed as part of these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69863a315f9883249bc172d1ea3c4670)