### PR TITLE
Grey key glyphs for helper text; localize autoplay; fix autofocus fallback

### DIFF
--- a/src/components/FlashcardArea.jsx
+++ b/src/components/FlashcardArea.jsx
@@ -17,6 +17,7 @@ export default function FlashcardArea({
   onAnswerModeChange,
 }) {
   const { t } = useI18n();
+  const helperKey = mode === "smart" ? "practiceHelperSmart" : "practiceHelperRandom";
 
   return (
     <section className={cn("flex-1", className)}>
@@ -83,7 +84,7 @@ export default function FlashcardArea({
           </div>
         </div>
 
-        <p className="text-xs text-muted-foreground">{t("practiceHelper")}</p>
+        <p className="text-xs text-muted-foreground">{t(helperKey)}</p>
 
         <Separator />
 

--- a/src/components/PracticeCardFeedback.jsx
+++ b/src/components/PracticeCardFeedback.jsx
@@ -70,6 +70,7 @@ export default function PracticeCardFeedback({
   const nextLabel = t("next") || "Next";
   const easyLabel = t("easy") || "Easy";
   const againLabel = t("again") || "Again";
+  const autoplayLabel = t("autoplay") || "Autoplay";
   const statusIcon = useMemo(() => {
     if (!last) return null;
     if (last === "correct") return CheckCircle2;
@@ -157,7 +158,7 @@ export default function PracticeCardFeedback({
                   }}
                   className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
                 />
-                Autoplay
+                {autoplayLabel}
               </label>
 
               {ttsError ? (

--- a/src/components/PracticeCardFront.jsx
+++ b/src/components/PracticeCardFront.jsx
@@ -15,6 +15,7 @@ import AppIcon from "./icons/AppIcon";
 
 export default function PracticeCardFront({
   sent,
+  answer,
   cardState,
   cardId,
   guess,
@@ -54,11 +55,12 @@ export default function PracticeCardFront({
   const hintLabel = t("hint") || "Hint";
   const revealLabel = t("reveal") || "Reveal";
   const skipLabel = t("skip") || "Skip";
+  const focusKey = cardId ?? answer ?? sent?.after ?? sent?.before ?? "";
 
   useEffect(() => {
     if (isFeedback) return;
     inputRef.current?.focus();
-  }, [cardId, isFeedback]);
+  }, [focusKey, isFeedback]);
 
   return (
     <div className="space-y-6">

--- a/src/i18n/strings.js
+++ b/src/i18n/strings.js
@@ -19,12 +19,15 @@ export const STRINGS = {
     easy: "Hawdd",
     hear: "Clywed",
     loading: "Llwytho...",
+    autoplay: "Awtochwarae",
 
     typeMode: "Teipio",
     tapMode: "Tapio",
     inputMode: "Dull ateb",
-    practiceHelper:
-      "Pwyswch Enter i wirio, yna defnyddiwch E/A i raddio yn y modd clyfar. Pwyswch H i glywed.",
+    practiceHelperSmart:
+      "🔲⏎ = Gwirio · 🔲E = Hawdd · 🔲A = Eto (modd clyfar) · 🔲H = Clywed",
+    practiceHelperRandom:
+      "🔲⏎ = Gwirio · 🔲H = Clywed · 🔲E = Hawdd + 🔲A = Eto (dim ond yn y modd clyfar)",
 
     noCards: "Dim cardiau ar gael. Gwiriwch eich hidlwyr/pecyn.",
 
@@ -105,12 +108,15 @@ export const STRINGS = {
     easy: "Easy",
     hear: "Hear",
     loading: "Loading...",
+    autoplay: "Autoplay",
 
     typeMode: "Type",
     tapMode: "Tap",
     inputMode: "Answer mode",
-    practiceHelper:
-      "Press Enter to check, then use E/A to grade in smart mode. Press H to hear.",
+    practiceHelperSmart:
+      "🔲⏎ = Check · 🔲E = Easy · 🔲A = Again (smart mode) · 🔲H = Hear",
+    practiceHelperRandom:
+      "🔲⏎ = Check · 🔲H = Hear · 🔲E = Easy + 🔲A = Again (smart mode only)",
 
     noCards: "No cards available. Check your filters/preset.",
 


### PR DESCRIPTION
### Motivation
- Make the on-screen keyboard helper visually consistent and clearly represent physical keys, and ensure the helper copy is mode-specific and localizable.
- Localize the autoplay label in the feedback UI for consistency with other strings.
- Make input autofocus robust when `cardId` is missing so focus updates reliably when the card changes.

### Description
- Updated `src/i18n/strings.js` to replace the single `practiceHelper` string with `practiceHelperSmart` and `practiceHelperRandom` for both `en` and `cy`, and switched helper key glyphs to a grey key-style prefix (e.g. `🔲⏎`, `🔲E`, `🔲H`) and added `autoplay` strings.
- Switched the helper line in `src/components/FlashcardArea.jsx` to select the appropriate key via `const helperKey = mode === "smart" ? "practiceHelperSmart" : "practiceHelperRandom"` and render `t(helperKey)`.
- Localized the autoplay label in `src/components/PracticeCardFeedback.jsx` by introducing `autoplayLabel = t("autoplay")` and using it in the UI.
- Improved autofocus logic in `src/components/PracticeCardFront.jsx` by adding a `focusKey = cardId ?? answer ?? sent?.after ?? sent?.before ?? ""` and depending on `focusKey` in the `useEffect` so inputs refocus when the visible card content changes.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and confirmed the server reported ready and reachable (succeeded).
- Captured a UI screenshot with a Playwright script against the running dev server and produced `artifacts/helper-text-grey-keys.png` to verify the updated helper text rendering (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69863d0a76108324b17373cad83bbd2d)