### PR TITLE
Add shared PageContainer for consistent layout width

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import Header from "./components/Header";
 import FlashcardArea from "./components/FlashcardArea";
 import FiltersPanel from "./components/FiltersPanel";
 import FilterSheet from "./components/FilterSheet";
+import PageContainer from "./components/layout/PageContainer";
 
 import { loadLeitnerMap, updateLeitner } from "./utils/leitner";
 import { getCardKey, pickRandomIndex, pickSmartIndex } from "./utils/pickNext";
@@ -239,7 +240,7 @@ export default function App() {
         onOpenHelp={() => openFiltersSheet(["item-start"])}
       />
 
-      <main className="mx-auto w-full max-w-6xl px-4 py-4 sm:px-6">
+      <PageContainer as="main" className="py-4">
         <div className="flex flex-col gap-6 md:flex-row">
           <div className="flex-1">
             <FlashcardArea
@@ -267,7 +268,7 @@ export default function App() {
             />
           </aside>
         </div>
-      </main>
+      </PageContainer>
 
       <FilterSheet open={filtersOpen} onOpenChange={setFiltersOpen}>
         <FiltersPanel

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -17,6 +17,7 @@ import {
   TooltipProvider,
 } from "./ui/tooltip";
 import { cn } from "../lib/cn";
+import PageContainer from "./layout/PageContainer";
 
 export default function Header({
   onOpenFilters,
@@ -27,7 +28,7 @@ export default function Header({
 
   return (
     <header className="sticky top-0 z-40 backdrop-blur bg-card" style={{ boxShadow: '0 1px 3px 0 rgb(0 0 0 / 0.05), 0 1px 2px -1px rgb(0 0 0 / 0.05)' }}>
-      <div className="mx-auto flex max-w-6xl items-end justify-between gap-2 sm:gap-4 px-3 pt-2 pb-2.5 sm:px-6 sm:pt-3 sm:pb-3 lg:pb-3.5">
+      <PageContainer className="flex items-end justify-between gap-2 sm:gap-4 pt-2 pb-2.5 sm:pt-3 sm:pb-3 lg:pb-3.5">
         
         {/* Logo lockup: dragon + wordmark */}
         <div className="brandLockup flex items-end min-w-0 shrink whitespace-nowrap">
@@ -172,7 +173,7 @@ export default function Header({
             </Tooltip>
           </div>
         </TooltipProvider>
-      </div>
+      </PageContainer>
     </header>
   );
 }

--- a/src/components/layout/PageContainer.jsx
+++ b/src/components/layout/PageContainer.jsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { cn } from "../../lib/cn";
+
+export default function PageContainer({
+  as: Component = "div",
+  className,
+  children,
+  ...props
+}) {
+  return (
+    <Component
+      className={cn(
+        "mx-auto w-full px-4 sm:px-6 lg:px-8 max-w-5xl md:max-w-6xl xl:max-w-7xl 2xl:max-w-[90rem]",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </Component>
+  );
+}


### PR DESCRIPTION
### Motivation
- Centralise page width control so large-screen layouts can scale beyond the duplicated `max-w-6xl` caps in multiple places. 
- Provide a single, reusable container that enforces consistent horizontal padding and responsive max-widths across the app.

### Description
- Add `src/components/layout/PageContainer.jsx`, a reusable container that applies `mx-auto w-full px-4 sm:px-6 lg:px-8` and responsive max-widths (`max-w-5xl md:max-w-6xl xl:max-w-7xl 2xl:max-w-[90rem]`) and uses the existing `cn()` helper. 
- Replace the header wrapper in `src/components/Header.jsx` with `PageContainer` so the header shares the same width/padding rules. 
- Replace the main wrapper in `src/App.jsx` with `PageContainer as="main"` to unify main content sizing with the header.

### Testing
- Ran the dev server with `npm run dev` which started successfully. 
- Captured a 1440px viewport screenshot using Playwright to verify the content width increased and left/right edges of the header and main content align correctly, which succeeded. 
- No automated unit tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698657170a548324b01c9ef4037b00f1)