### PR TITLE
Apply typography tokens and responsive text utilities

### DIFF
--- a/src/components/FiltersPanel.jsx
+++ b/src/components/FiltersPanel.jsx
@@ -156,7 +156,7 @@ export default function FiltersPanel({
               <p className="text-xs text-muted-foreground">
                 {t("quickPacksSubtitle")}
               </p>
-              <p className="text-[0.7rem] text-muted-foreground mt-1">
+              <p className="text-xs sm:text-sm text-muted-foreground mt-1">
                 {t("quickPacksHint")}
               </p>
             </div>

--- a/src/components/FlashcardArea.jsx
+++ b/src/components/FlashcardArea.jsx
@@ -23,14 +23,14 @@ export default function FlashcardArea({
       <div className="space-y-4 rounded-[var(--radius)] border border-border bg-[hsl(var(--panel))] p-5 sm:p-6">
         <div className="flex flex-wrap items-center justify-between gap-3 text-sm text-muted-foreground">
           <div className="flex items-center gap-2">
-            <span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+            <span className="text-xs sm:text-sm font-semibold uppercase tracking-wide text-muted-foreground">
               {progressText}
             </span>
           </div>
 
           <div className="flex flex-wrap items-center gap-3">
             <div className="flex items-center gap-2">
-              <span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+              <span className="text-xs sm:text-sm font-semibold uppercase tracking-wide text-muted-foreground">
                 {t("mode")}
               </span>
               <ToggleGroup
@@ -56,7 +56,7 @@ export default function FlashcardArea({
 
             {onAnswerModeChange && (
               <div className="flex items-center gap-2">
-                <span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                <span className="text-xs sm:text-sm font-semibold uppercase tracking-wide text-muted-foreground">
                   {t("ateb") || "Answer"}
                 </span>
                 <ToggleGroup

--- a/src/components/PracticeCardFront.jsx
+++ b/src/components/PracticeCardFront.jsx
@@ -87,7 +87,7 @@ export default function PracticeCardFront({
               }}
               aria-hidden="true"
             />
-            <h1 className="relative z-10 text-center text-4xl xs:text-5xl sm:text-6xl md:text-7xl font-extrabold tracking-tight text-[hsl(var(--cymru-green))] leading-none break-words max-w-full">
+            <h1 className="relative z-10 text-center text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-extrabold tracking-tight text-[hsl(var(--cymru-green))] leading-none break-words max-w-full">
               {baseword}
             </h1>
           </div>

--- a/src/index.css
+++ b/src/index.css
@@ -206,7 +206,29 @@
         "Apple Color Emoji",
         "Segoe UI Emoji"
       );
+    font-size: var(--text-body-size);
+    line-height: var(--text-body-line);
     @apply bg-background text-foreground;
+  }
+
+  h1,
+  h2,
+  h3 {
+    font-family: var(
+        --font-display,
+        ui-sans-serif,
+        system-ui,
+        -apple-system,
+        Segoe UI,
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji"
+      );
+    font-size: var(--text-display-size);
+    line-height: var(--text-display-line);
+    letter-spacing: var(--text-display-tracking);
   }
 
   a {


### PR DESCRIPTION
### Motivation
- Ensure global typography tokens drive body and display sizing so the app respects `--text-body-*` and `--text-display-*` design tokens for consistent sizing and line-height.
- Replace ad-hoc hardcoded font sizes with responsive Tailwind utilities to match the established scale and improve readability across breakpoints.

### Description
- Add base styles to `src/index.css` to apply `--text-body-size` and `--text-body-line` to `body` and to apply `--text-display-size`, `--text-display-line`, and `--text-display-tracking` to `h1`, `h2`, and `h3`.
- Replace `text-[11px]` instances in `src/components/FlashcardArea.jsx` with `text-xs sm:text-sm` for responsive label sizing.
- Replace `text-[0.7rem]` in `src/components/FiltersPanel.jsx` with `text-xs sm:text-sm` for hint text.
- Reduce the oversized `PracticeCardFront` heading (`text-4xl xs:text-5xl sm:text-6xl md:text-7xl`) to a responsive set aligned with scale (`text-2xl sm:text-3xl md:text-4xl lg:text-5xl`) in `src/components/PracticeCardFront.jsx`.
- Files changed: `src/index.css`, `src/components/FlashcardArea.jsx`, `src/components/FiltersPanel.jsx`, `src/components/PracticeCardFront.jsx`.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` which launched Vite successfully and served the app endpoint, and the run completed without errors.
- Captured a visual verification screenshot using Playwright (script visited `http://127.0.0.1:4173/mutationtrainer-react/` and saved `artifacts/typography-updates.png`), and the script completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698659d9fd0083248bcc9bca21209d8e)