### PR TITLE
Centralize toggle sizing in FlashcardArea

### DIFF
--- a/src/components/FlashcardArea.jsx
+++ b/src/components/FlashcardArea.jsx
@@ -37,17 +37,18 @@ export default function FlashcardArea({
                 type="single"
                 value={mode}
                 onValueChange={(value) => value && onModeChange(value)}
+                size="sm"
                 className="flex items-center gap-1 rounded-lg border border-border bg-card p-1 sm:flex-nowrap"
               >
                 <ToggleGroupItem
                   value="random"
-                  className="rounded-md px-2.5 py-1 text-xs sm:text-sm font-semibold text-foreground transition-colors border border-transparent hover:bg-muted/50 data-[state=on]:bg-primary data-[state=on]:text-primary-foreground data-[state=on]:border-primary/60"
+                  className="rounded-md font-semibold text-foreground transition-colors border border-transparent hover:bg-muted/50 data-[state=on]:bg-primary data-[state=on]:text-primary-foreground data-[state=on]:border-primary/60"
                 >
                   {t("random")}
                 </ToggleGroupItem>
                 <ToggleGroupItem
                   value="smart"
-                  className="rounded-md px-2.5 py-1 text-xs sm:text-sm font-semibold text-foreground transition-colors border border-transparent hover:bg-muted/50 data-[state=on]:bg-primary data-[state=on]:text-primary-foreground data-[state=on]:border-primary/60"
+                  className="rounded-md font-semibold text-foreground transition-colors border border-transparent hover:bg-muted/50 data-[state=on]:bg-primary data-[state=on]:text-primary-foreground data-[state=on]:border-primary/60"
                 >
                   {t("smart")}
                 </ToggleGroupItem>
@@ -63,17 +64,18 @@ export default function FlashcardArea({
                   type="single"
                   value={answerMode}
                   onValueChange={(value) => value && onAnswerModeChange(value)}
+                  size="sm"
                   className="flex items-center gap-1 rounded-lg border border-border bg-card p-1 sm:flex-nowrap"
                 >
                   <ToggleGroupItem
                     value="type"
-                    className="rounded-md px-2.5 py-1 text-xs sm:text-sm font-semibold text-foreground transition-colors border border-transparent hover:bg-muted/50 data-[state=on]:bg-primary data-[state=on]:text-primary-foreground data-[state=on]:border-primary/60"
+                    className="rounded-md font-semibold text-foreground transition-colors border border-transparent hover:bg-muted/50 data-[state=on]:bg-primary data-[state=on]:text-primary-foreground data-[state=on]:border-primary/60"
                   >
                     {t("typeMode") || "Type"}
                   </ToggleGroupItem>
                   <ToggleGroupItem
                     value="tap"
-                    className="rounded-md px-2.5 py-1 text-xs sm:text-sm font-semibold text-foreground transition-colors border border-transparent hover:bg-muted/50 data-[state=on]:bg-primary data-[state=on]:text-primary-foreground data-[state=on]:border-primary/60"
+                    className="rounded-md font-semibold text-foreground transition-colors border border-transparent hover:bg-muted/50 data-[state=on]:bg-primary data-[state=on]:text-primary-foreground data-[state=on]:border-primary/60"
                   >
                     {t("tapMode") || "Tap"}
                   </ToggleGroupItem>


### PR DESCRIPTION
### Motivation
- Centralize toggle sizing so `ToggleGroup` controls size variants from `src/components/ui/toggle.tsx` instead of relying on per-item padding and text-size utilities.

### Description
- Set `size="sm"` on `ToggleGroup` instances in `src/components/FlashcardArea.jsx` and removed the `px-2.5 py-1 text-xs sm:text-sm` classes from `ToggleGroupItem` elements so sizing is driven by the shared toggle variants.

### Testing
- Started the dev server with `npm run dev` and ran a Playwright script to load the page and capture a screenshot, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69865ad641ec8324ba3a50c81a56a80e)