### PR TITLE
Remove practice helper line from flashcard header

### DIFF
--- a/src/components/FlashcardArea.jsx
+++ b/src/components/FlashcardArea.jsx
@@ -23,16 +23,12 @@ export default function FlashcardArea({
       <div className="space-y-4 rounded-[var(--radius)] border border-border bg-[hsl(var(--panel))] p-5 sm:p-6">
         <div className="flex flex-wrap items-center justify-between gap-3 text-sm text-muted-foreground">
           <div className="flex items-center gap-2">
-            <span className="text-xs sm:text-sm font-semibold uppercase tracking-wide text-muted-foreground">
-              {progressText}
-            </span>
+            <span className="mt-subtitle">{progressText}</span>
           </div>
 
           <div className="flex flex-wrap items-center gap-3">
             <div className="flex items-center gap-2">
-              <span className="text-xs sm:text-sm font-semibold uppercase tracking-wide text-muted-foreground">
-                {t("mode")}
-              </span>
+              <span className="mt-subtitle">{t("mode")}</span>
               <ToggleGroup
                 type="single"
                 value={mode}
@@ -57,9 +53,7 @@ export default function FlashcardArea({
 
             {onAnswerModeChange && (
               <div className="flex items-center gap-2">
-                <span className="text-xs sm:text-sm font-semibold uppercase tracking-wide text-muted-foreground">
-                  {t("ateb") || "Answer"}
-                </span>
+                <span className="mt-subtitle">{t("ateb") || "Answer"}</span>
                 <ToggleGroup
                   type="single"
                   value={answerMode}
@@ -84,8 +78,6 @@ export default function FlashcardArea({
             )}
           </div>
         </div>
-
-        <p className="text-xs text-muted-foreground">{t("practiceHelper")}</p>
 
         <Separator />
 

--- a/src/index.css
+++ b/src/index.css
@@ -101,6 +101,9 @@
   --text-label-size: 0.875rem;
   --text-label-line: 1.4;
   --text-label-tracking: 0.04em;
+  --text-subtitle-size: clamp(0.62rem, 0.5rem + 0.5vw, 0.82rem);
+  --text-subtitle-line: 1.4;
+  --text-subtitle-tracking: 0.08em;
   --text-display-size: clamp(1.75rem, 1.3rem + 1.2vw, 2.6rem);
   --text-display-line: 1.2;
   --text-display-tracking: -0.01em;
@@ -314,5 +317,15 @@
   }
   .mt-pill-on {
     @apply bg-primary text-primary-foreground hover:bg-primary/90;
+  }
+
+  .mt-subtitle {
+    font-family: var(--font-body);
+    font-size: var(--text-subtitle-size);
+    line-height: var(--text-subtitle-line);
+    letter-spacing: var(--text-subtitle-tracking);
+    text-transform: uppercase;
+    font-weight: 400;
+    @apply text-muted-foreground;
   }
 }


### PR DESCRIPTION
### Motivation
- Simplify the flashcard header layout by removing the small helper line of text under the header controls. 
- Ensure subtitle/label styling is consistent and compact by using a shared subtitle utility and tighter tracking.

### Description
- Remove the helper paragraph `t("practiceHelper")` from `src/components/FlashcardArea.jsx` so the header is cleaner.
- Use the shared `.mt-subtitle` utility for header labels in `FlashcardArea.jsx` to standardize subtitle typography.
- Add subtitle typography tokens `--text-subtitle-size`, `--text-subtitle-line`, and `--text-subtitle-tracking` and a `.mt-subtitle` rule to `src/index.css` to control size, line-height, and tracking.

### Testing
- Started the dev server with `npm run dev` and confirmed Vite served the app successfully (succeeded).
- Ran a Playwright script that loaded the app and captured a full-page screenshot `artifacts/subtitle-labels-no-helper.png` for visual verification (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69866dd4622c83249f155dd2dc7030fe)