### PR TITLE
Improve hero pill responsiveness

### DIFF
--- a/src/components/PracticeCardChoices.jsx
+++ b/src/components/PracticeCardChoices.jsx
@@ -90,9 +90,9 @@ export default function PracticeCardChoices({
         <div className="relative inline-flex max-w-full">
           <Badge
             variant="secondary"
-            className="rounded-full border-2 border-[hsl(var(--cymru-green-light))] bg-[hsl(var(--hero-pill-bg))] px-6 py-3 sm:px-12 sm:py-5 md:px-14 md:py-6 shadow-sm max-w-full"
+            className="w-full max-w-[min(100%,52rem)] rounded-full border-2 border-[hsl(var(--cymru-green-light))] bg-[hsl(var(--hero-pill-bg))] px-[clamp(1.5rem,5vw,4.5rem)] py-[clamp(1rem,3vw,2.25rem)] shadow-sm"
           >
-            <h1 className="text-center text-4xl xs:text-5xl sm:text-6xl md:text-7xl font-extrabold tracking-tight text-primary leading-none break-words max-w-full">
+            <h1 className="text-center text-[clamp(2.5rem,6vw,5.25rem)] font-extrabold tracking-tight text-primary leading-[0.95] text-balance break-words">
               {baseword}
             </h1>
           </Badge>


### PR DESCRIPTION
### Motivation
- The hero pill headline and padding were scaling to awkwardly large sizes on wide viewports, making long words render poorly while the pill should remain bold but highly responsive.

### Description
- Tweak `src/components/PracticeCardChoices.jsx` to constrain the pill width with `max-w-[min(100%,52rem)]` and apply responsive padding using `px-[clamp(1.5rem,5vw,4.5rem)]` and `py-[clamp(1rem,3vw,2.25rem)]` to avoid oversized pills on large screens.
- Replace fixed heading sizes with a typographic clamp `text-[clamp(2.5rem,6vw,5.25rem)]` and set `leading-[0.95]` plus `text-balance` to improve wrapping and visual balance for long words.

### Testing
- Started the dev server with `npm run dev` and confirmed Vite served the app successfully at the local and network URLs.
- Ran a Playwright script that loaded the app at `1728x896` and captured `artifacts/hero-pill-responsive.png`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698674731e908324b4baafdd3f1b1ce6)