### PR TITLE
Make action button size scale at md/lg breakpoints

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -30,7 +30,8 @@ const buttonVariants = cva(
       },
       size: {
         default: "h-9 px-4 py-2",
-        action: "h-7 px-2 py-1 text-xs sm:h-9 sm:px-4 sm:py-2 sm:text-sm",
+        action:
+          "h-7 px-2 py-1 text-xs sm:h-9 sm:px-4 sm:py-2 sm:text-sm md:h-10 md:px-5 md:text-base lg:h-11 lg:px-6 lg:text-lg",
         xs: "h-7 rounded-md px-2 text-xs",
         sm: "h-8 rounded-md px-3 text-xs",
         lg: "h-10 rounded-md px-8",


### PR DESCRIPTION
### Motivation

- Ensure action-style buttons scale up at medium and large breakpoints so action buttons remain visually consistent and legible across responsive layouts.

### Description

- Update the shared `action` size variant in `src/components/ui/button.tsx` to include `md`/`lg` sizing and typography (added `md:h-10 md:px-5 md:text-base lg:h-11 lg:px-6 lg:text-lg`) while keeping the change centralized to the single shared variant.

### Testing

- Started the dev server with `npm run dev` and it launched successfully.
- Ran a Playwright script to navigate to the app and capture a UI screenshot (`artifacts/action-button-size.png`), and the script completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69867640cf24832484fe7225825cfaf7)