### PR TITLE
Adjust `sm` toggle size to scale responsively at md/lg

### DIFF
--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -15,7 +15,7 @@ const toggleVariants = cva(
       },
       size: {
         default: "h-9 px-2 min-w-9",
-        sm: "h-8 px-1.5 min-w-8",
+        sm: "h-8 px-1.5 min-w-8 md:h-9 md:px-2 md:min-w-9 lg:h-10 lg:px-2.5 lg:min-w-10",
         lg: "h-10 px-2.5 min-w-10",
       },
     },


### PR DESCRIPTION
### Motivation
- Ensure toggle groups remain visually consistent when components force `size="sm"` by making the `sm` variant scale up on larger breakpoints.

### Description
- Update `sm` variant in `src/components/ui/toggle.tsx` to include `md:` and `lg:` classes so `sm` expands to the `md`/`lg` sizes at larger viewports.

### Testing
- Started the dev server with `npm run dev` which launched Vite successfully, and an attempted Playwright screenshot run failed due to a browser crash so no visual snapshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986771dc3048324a095330ed322fa66)