### PR TITLE
Align shuffle placement and translation icon styling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -194,6 +194,14 @@ export default function App() {
       return;
     }
 
+    if (result === "shuffle") {
+      if (!currentRow) return;
+      const key = getCardKey(currentRow, currentIdx);
+      pushRecent(key);
+      pickNext(leitnerRef.current);
+      return;
+    }
+
     // grading only: update Leitner but do NOT navigate
     if (!currentRow) return;
 
@@ -210,6 +218,11 @@ export default function App() {
 
     // IMPORTANT: no pickNext() here for standard grading
   }
+
+  const handleShuffle = () => {
+    if (mode !== "random") return;
+    onResult({ result: "shuffle" });
+  };
 
   function handleTogglePreset(id) {
     setActivePresetId((prev) => (prev === id ? null : id));
@@ -251,6 +264,7 @@ export default function App() {
               deckLabel={presetLabel}
               currentRow={currentRow}
               onResult={onResult}
+              onShuffle={handleShuffle}
               answerMode={answerMode}
               onAnswerModeChange={setAnswerMode}
               deckRows={filtered}

--- a/src/components/FlashcardArea.jsx
+++ b/src/components/FlashcardArea.jsx
@@ -3,6 +3,15 @@ import { useI18n } from "../i18n/I18nContext";
 import { cn } from "../lib/cn";
 import { ToggleGroup, ToggleGroupItem } from "./ui/toggle-group";
 import { Separator } from "./ui/separator";
+import { Button } from "./ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "./ui/tooltip";
+import { Shuffle } from "lucide-react";
+import AppIcon from "./icons/AppIcon";
 
 export default function FlashcardArea({
   className,
@@ -15,8 +24,11 @@ export default function FlashcardArea({
   answerMode,
   deckRows,
   onAnswerModeChange,
+  onShuffle,
 }) {
   const { t } = useI18n();
+  const shuffleLabel = t("shuffle") || "Shuffle";
+  const showShuffle = mode === "random";
 
   return (
     <section className={cn("flex-1", className)}>
@@ -29,26 +41,28 @@ export default function FlashcardArea({
           <div className="flex flex-wrap items-center gap-3">
             <div className="flex items-center gap-2">
               <span className="mt-subtitle">{t("mode")}</span>
-              <ToggleGroup
-                type="single"
-                value={mode}
-                onValueChange={(value) => value && onModeChange(value)}
-                size="sm"
-                className="flex items-center gap-1 rounded-lg border border-border bg-card p-1 sm:flex-nowrap"
-              >
-                <ToggleGroupItem
-                  value="random"
-                  className="rounded-md font-semibold text-foreground transition-colors border border-transparent hover:bg-muted/50 data-[state=on]:bg-primary data-[state=on]:text-primary-foreground data-[state=on]:border-primary/60"
+              <div className="flex items-center gap-2">
+                <ToggleGroup
+                  type="single"
+                  value={mode}
+                  onValueChange={(value) => value && onModeChange(value)}
+                  size="sm"
+                  className="flex items-center gap-1 rounded-lg border border-border bg-card p-1 sm:flex-nowrap"
                 >
-                  {t("random")}
-                </ToggleGroupItem>
-                <ToggleGroupItem
-                  value="smart"
-                  className="rounded-md font-semibold text-foreground transition-colors border border-transparent hover:bg-muted/50 data-[state=on]:bg-primary data-[state=on]:text-primary-foreground data-[state=on]:border-primary/60"
-                >
-                  {t("smart")}
-                </ToggleGroupItem>
-              </ToggleGroup>
+                  <ToggleGroupItem
+                    value="random"
+                    className="rounded-md font-semibold text-foreground transition-colors border border-transparent hover:bg-muted/50 data-[state=on]:bg-primary data-[state=on]:text-primary-foreground data-[state=on]:border-primary/60"
+                  >
+                    {t("random")}
+                  </ToggleGroupItem>
+                  <ToggleGroupItem
+                    value="smart"
+                    className="rounded-md font-semibold text-foreground transition-colors border border-transparent hover:bg-muted/50 data-[state=on]:bg-primary data-[state=on]:text-primary-foreground data-[state=on]:border-primary/60"
+                  >
+                    {t("smart")}
+                  </ToggleGroupItem>
+                </ToggleGroup>
+              </div>
             </div>
 
             {onAnswerModeChange && (
@@ -76,6 +90,30 @@ export default function FlashcardArea({
                 </ToggleGroup>
               </div>
             )}
+
+            {showShuffle ? (
+              <div className="flex items-center ml-auto">
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        onClick={onShuffle}
+                        className="h-10 w-10 bg-[hsl(var(--cymru-green-light-wash))] text-[hsl(var(--cymru-green-light))] hover:bg-[hsl(var(--cymru-green-light-wash))]"
+                        aria-label={shuffleLabel}
+                      >
+                        <AppIcon icon={Shuffle} className="h-4 w-4" aria-hidden="true" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent className="bg-[hsl(var(--cymru-green))] text-white text-xs">
+                      {shuffleLabel}
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              </div>
+            ) : null}
           </div>
         </div>
 

--- a/src/components/PracticeCard.jsx
+++ b/src/components/PracticeCard.jsx
@@ -422,6 +422,7 @@ export default function PracticeCard({
                 onReveal={onReveal}
                 onSkip={onSkip}
                 t={t}
+                mode={mode}
                 tooltipTranslate={tooltipTranslate}
                 tooltipWordCategory={wordCategory}
                 guess={guess}
@@ -445,6 +446,7 @@ export default function PracticeCard({
                 onReveal={onReveal}
                 onSkip={onSkip}
                 t={t}
+                mode={mode}
                 tooltipTranslate={tooltipTranslate}
                 tooltipWordCategory={wordCategory}
               />

--- a/src/components/PracticeCardChoices.jsx
+++ b/src/components/PracticeCardChoices.jsx
@@ -1,14 +1,27 @@
 import { useEffect, useMemo } from "react";
 import { Button } from "./ui/button";
+import { ButtonGroup } from "./ui/button-group";
 import { Badge } from "./ui/badge";
 import { Separator } from "./ui/separator";
 import { cn } from "../lib/cn";
+import LanguagesIcon from "./icons/LanguagesIcon";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "./ui/tooltip";
 import {
   HoverCard,
   HoverCardContent,
   HoverCardTrigger,
 } from "./ui/hover-card";
-import { CheckCircle2, Lightbulb, MonitorPlay, SkipForward } from "lucide-react";
+import {
+  CheckCircle2,
+  Lightbulb,
+  MonitorPlay,
+  SkipForward,
+} from "lucide-react";
 import AppIcon from "./icons/AppIcon";
 
 function normalizeChoice(value) {
@@ -37,6 +50,7 @@ export default function PracticeCardChoices({
   tooltipTranslate,
   tooltipWordCategory,
   guess,
+  mode = "random",
 }) {
   const isFeedback = cardState === "feedback";
   const baseword = sent?.base || "_____";
@@ -80,9 +94,20 @@ export default function PracticeCardChoices({
   const hintLabel = t("hint") || "Hint";
   const revealLabel = t("reveal") || "Reveal";
   const skipLabel = t("skip") || "Skip";
-
   const normalizedAnswer = normalizeChoice(answer);
   const normalizedGuess = normalizeChoice(guess);
+  const utilityBaseClass =
+    "h-10 w-10 shadow-none border border-transparent hover:border-border/60";
+  const hintClass =
+    "bg-[hsl(var(--cymru-green-light-wash))] text-[hsl(var(--cymru-green-light))] hover:bg-[hsl(var(--cymru-green-light-wash))]";
+  const revealClass =
+    "bg-[hsl(var(--cymru-red-wash))] text-[hsl(var(--cymru-red))] hover:bg-[hsl(var(--cymru-red-wash))]";
+  const skipClass =
+    "bg-[hsl(var(--cymru-gold-wash))] text-[hsl(var(--cymru-gold))] hover:bg-[hsl(var(--cymru-gold-wash))]";
+  const tooltipBaseClass = "text-white";
+  const tooltipGreenClass = "bg-[hsl(var(--cymru-green))] text-white";
+  const tooltipRedClass = "bg-[hsl(var(--cymru-red))] text-white";
+  const tooltipGoldClass = "bg-[hsl(var(--cymru-gold))] text-white";
 
   return (
     <div className="space-y-6">
@@ -103,9 +128,9 @@ export default function PracticeCardChoices({
                 <button
                   type="button"
                   aria-label="Translation and category"
-                  className="absolute -right-1 -top-1 inline-flex h-6 w-6 items-center justify-center rounded-full border border-destructive bg-card text-xs font-extrabold text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive hover:bg-destructive/10 hover:shadow-sm transition-colors"
+                  className="absolute -right-1 -top-1 inline-flex h-7 w-7 items-center justify-center rounded-full border-2 border-[hsl(var(--cymru-green-light))] bg-card text-[hsl(var(--cymru-green-light))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--cymru-green-light))] hover:bg-[hsl(var(--cymru-green-light-wash))] hover:shadow-sm transition-colors"
                 >
-                  ?
+                  <LanguagesIcon size={14} color="currentColor" strokeWidth={2} />
                 </button>
               </HoverCardTrigger>
               <HoverCardContent
@@ -187,53 +212,84 @@ export default function PracticeCardChoices({
         })}
       </div>
 
-      <div className="flex flex-wrap items-center gap-2 justify-center sm:justify-start">
-        <Button
-          type="button"
-          variant="default"
-          onClick={onCheck}
-          size="action"
-          className="flex-1 sm:flex-none min-w-[120px]"
-        >
-          <AppIcon icon={CheckCircle2} className="h-4 w-4" aria-hidden="true" />
-          {checkLabel}
-        </Button>
+      <TooltipProvider>
+        <div className="flex flex-wrap items-center justify-center gap-3 sm:justify-between">
+          <div className="flex flex-wrap items-center gap-2">
+            <ButtonGroup>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="default"
+                    onClick={onToggleHint}
+                    size="icon"
+                    className={cn(utilityBaseClass, hintClass)}
+                    aria-label={hintLabel}
+                  >
+                    <AppIcon icon={Lightbulb} className="h-4 w-4" aria-hidden="true" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent className={cn(tooltipGreenClass, tooltipBaseClass)}>
+                  {hintLabel}
+                </TooltipContent>
+              </Tooltip>
+            </ButtonGroup>
 
-        <Button
-          type="button"
-          variant="outline-secondary"
-          onClick={onToggleHint}
-          size="action"
-          className="flex-1 sm:flex-none min-w-[120px]"
-        >
-          <AppIcon icon={Lightbulb} className="h-4 w-4" aria-hidden="true" />
-          {hintLabel}
-        </Button>
+            <ButtonGroup className="flex-wrap">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="default"
+                    onClick={onReveal}
+                    disabled={isFeedback}
+                    size="icon"
+                    className={cn(utilityBaseClass, revealClass)}
+                    aria-label={revealLabel}
+                  >
+                    <AppIcon icon={MonitorPlay} className="h-4 w-4" aria-hidden="true" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent className={cn(tooltipRedClass, tooltipBaseClass)}>
+                  {revealLabel}
+                </TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="default"
+                    onClick={onSkip}
+                    disabled={isFeedback}
+                    size="icon"
+                    className={cn(utilityBaseClass, skipClass)}
+                    aria-label={skipLabel}
+                  >
+                    <AppIcon icon={SkipForward} className="h-4 w-4" aria-hidden="true" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent className={cn(tooltipGoldClass, tooltipBaseClass)}>
+                  {skipLabel}
+                </TooltipContent>
+              </Tooltip>
+            </ButtonGroup>
 
-        <Button
-          type="button"
-          variant="ghost"
-          onClick={onReveal}
-          disabled={isFeedback}
-          size="action"
-          className="flex-1 sm:flex-none min-w-[120px]"
-        >
-          <AppIcon icon={MonitorPlay} className="h-4 w-4" aria-hidden="true" />
-          {revealLabel}
-        </Button>
+          </div>
 
-        <Button
-          type="button"
-          variant="outline-accent"
-          onClick={onSkip}
-          disabled={isFeedback}
-          size="action"
-          className="flex-1 sm:flex-none min-w-[120px]"
-        >
-          <AppIcon icon={SkipForward} className="h-4 w-4" aria-hidden="true" />
-          {skipLabel}
-        </Button>
-      </div>
+          <ButtonGroup>
+            <Button
+              type="button"
+              variant="default"
+              onClick={onCheck}
+              size="action"
+              className="w-full sm:w-auto bg-[hsl(var(--cymru-green))] text-white hover:bg-[hsl(var(--cymru-green)/0.9)] whitespace-nowrap shadow-sm font-semibold"
+            >
+              <AppIcon icon={CheckCircle2} className="h-5 w-5" aria-hidden="true" />
+              {checkLabel}
+            </Button>
+          </ButtonGroup>
+        </div>
+      </TooltipProvider>
 
       {showHint && hintText ? (
         <div className="rounded-2xl border border-border bg-muted px-4 py-3 text-sm text-foreground">

--- a/src/components/PracticeCardFeedback.jsx
+++ b/src/components/PracticeCardFeedback.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "./ui/button";
+import { ButtonGroup } from "./ui/button-group";
 import { Card, CardContent } from "./ui/card";
 import { badgeVariants } from "./ui/badge";
 import { cn } from "../lib/cn";
@@ -69,7 +70,11 @@ export default function PracticeCardFeedback({
   const hearButtonVariant = "cymru-light";
   const nextLabel = t("next") || "Next";
   const easyLabel = t("easy") || "Easy";
-  const againLabel = t("again") || "Again";
+  const hardLabel = t("hard") || "Hard";
+  const greenOutlineClass =
+    "border-[hsl(var(--cymru-green))] text-[hsl(var(--cymru-green))] hover:bg-[hsl(var(--cymru-green-wash))] hover:text-[hsl(var(--cymru-green))] hover:shadow-sm";
+  const redOutlineClass =
+    "border-[hsl(var(--cymru-red))] text-[hsl(var(--cymru-red))] hover:bg-[hsl(var(--cymru-red-wash))] hover:text-[hsl(var(--cymru-red))] hover:shadow-sm";
   const statusIcon = useMemo(() => {
     if (!last) return null;
     if (last === "correct") return CheckCircle2;
@@ -178,35 +183,41 @@ export default function PracticeCardFeedback({
           <div className="flex flex-wrap justify-end gap-2">
             {isSmartMode ? (
               <>
-                <Button
-                  type="button"
-                  variant="outline-secondary"
-                  onClick={() => handleSmartResult("again")}
-                  size="action"
-                  disabled={isSubmitting}
-                >
-                  <AppIcon icon={Undo2} className="h-4 w-4" aria-hidden="true" />
-                  {againLabel}
-                </Button>
-                <Button
-                  type="button"
-                  onClick={() => handleSmartResult("next")}
-                  size="action"
-                  disabled={isSubmitting}
-                >
-                  {nextLabel}
-                  <AppIcon icon={ArrowRight} className="h-5 w-5" aria-hidden="true" />
-                </Button>
-                <Button
-                  type="button"
-                  variant="success"
-                  onClick={() => handleSmartResult("easy")}
-                  size="action"
-                  disabled={isSubmitting}
-                >
-                  <AppIcon icon={CheckCircle2} className="h-4 w-4" aria-hidden="true" />
-                  {easyLabel}
-                </Button>
+                <ButtonGroup className="flex-wrap">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => handleSmartResult("again")}
+                    size="action"
+                    disabled={isSubmitting}
+                    className={redOutlineClass}
+                  >
+                    <AppIcon icon={X} className="h-4 w-4" aria-hidden="true" />
+                    {hardLabel}
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => handleSmartResult("easy")}
+                    size="action"
+                    disabled={isSubmitting}
+                    className={greenOutlineClass}
+                  >
+                    <AppIcon icon={CheckCircle2} className="h-4 w-4" aria-hidden="true" />
+                    {easyLabel}
+                  </Button>
+                </ButtonGroup>
+                <ButtonGroup>
+                  <Button
+                    type="button"
+                    onClick={() => handleSmartResult("next")}
+                    size="action"
+                    disabled={isSubmitting}
+                  >
+                    {nextLabel}
+                    <AppIcon icon={ArrowRight} className="h-5 w-5" aria-hidden="true" />
+                  </Button>
+                </ButtonGroup>
               </>
             ) : (
               <Button type="button" onClick={onNext} size="action">

--- a/src/components/PracticeCardFront.jsx
+++ b/src/components/PracticeCardFront.jsx
@@ -1,15 +1,29 @@
 import { useEffect, useMemo, useRef } from "react";
 import { Button } from "./ui/button";
+import { ButtonGroup } from "./ui/button-group";
 import { Badge } from "./ui/badge";
 import HeroPill from "./HeroPill";
 import { Input } from "./ui/input";
 import { Separator } from "./ui/separator";
+import { cn } from "../lib/cn";
+import LanguagesIcon from "./icons/LanguagesIcon";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "./ui/tooltip";
 import {
   HoverCard,
   HoverCardContent,
   HoverCardTrigger,
 } from "./ui/hover-card";
-import { CheckCircle2, Lightbulb, MonitorPlay, SkipForward } from "lucide-react";
+import {
+  CheckCircle2,
+  Lightbulb,
+  MonitorPlay,
+  SkipForward,
+} from "lucide-react";
 import AppIcon from "./icons/AppIcon";
 
 export default function PracticeCardFront({
@@ -29,6 +43,7 @@ export default function PracticeCardFront({
   onReveal,
   onSkip,
   t,
+  mode = "random",
   tooltipTranslate,
   tooltipWordCategory,
 }) {
@@ -53,6 +68,18 @@ export default function PracticeCardFront({
   const hintLabel = t("hint") || "Hint";
   const revealLabel = t("reveal") || "Reveal";
   const skipLabel = t("skip") || "Skip";
+  const utilityBaseClass =
+    "h-10 w-10 shadow-none border border-transparent hover:border-border/60";
+  const hintClass =
+    "bg-[hsl(var(--cymru-green-light-wash))] text-[hsl(var(--cymru-green-light))] hover:bg-[hsl(var(--cymru-green-light-wash))]";
+  const revealClass =
+    "bg-[hsl(var(--cymru-red-wash))] text-[hsl(var(--cymru-red))] hover:bg-[hsl(var(--cymru-red-wash))]";
+  const skipClass =
+    "bg-[hsl(var(--cymru-gold-wash))] text-[hsl(var(--cymru-gold))] hover:bg-[hsl(var(--cymru-gold-wash))]";
+  const tooltipBaseClass = "text-white";
+  const tooltipGreenClass = "bg-[hsl(var(--cymru-green))] text-white";
+  const tooltipRedClass = "bg-[hsl(var(--cymru-red))] text-white";
+  const tooltipGoldClass = "bg-[hsl(var(--cymru-gold))] text-white";
 
   useEffect(() => {
     if (isFeedback) return;
@@ -72,9 +99,9 @@ export default function PracticeCardFront({
                 <button
                   type="button"
                   aria-label="Translation and category"
-                  className="absolute -right-1 -top-1 inline-flex h-6 w-6 items-center justify-center rounded-full border border-destructive bg-card text-xs font-extrabold text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive hover:bg-destructive/10 hover:shadow-sm transition-colors"
+                  className="absolute -right-1 -top-1 inline-flex h-7 w-7 items-center justify-center rounded-full border-2 border-[hsl(var(--cymru-green-light))] bg-card text-[hsl(var(--cymru-green-light))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--cymru-green-light))] hover:bg-[hsl(var(--cymru-green-light-wash))] hover:shadow-sm transition-colors"
                 >
-                  ?
+                  <LanguagesIcon size={14} color="currentColor" strokeWidth={2} />
                 </button>
               </HoverCardTrigger>
               <HoverCardContent
@@ -130,53 +157,84 @@ export default function PracticeCardFront({
 
       <Separator />
 
-      <div className="flex flex-wrap items-center gap-2 justify-center sm:justify-start">
-        <Button
-          type="button"
-          variant="default"
-          onClick={onCheck}
-          size="action"
-          className="flex-1 sm:flex-none min-w-[120px]"
-        >
-          <AppIcon icon={CheckCircle2} className="h-4 w-4" aria-hidden="true" />
-          {checkLabel}
-        </Button>
+      <TooltipProvider>
+        <div className="flex flex-wrap items-center justify-center gap-3 sm:justify-between">
+          <div className="flex flex-wrap items-center gap-2">
+            <ButtonGroup>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="default"
+                    onClick={onToggleHint}
+                    size="icon"
+                    className={cn(utilityBaseClass, hintClass)}
+                    aria-label={hintLabel}
+                  >
+                    <AppIcon icon={Lightbulb} className="h-4 w-4" aria-hidden="true" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent className={cn(tooltipGreenClass, tooltipBaseClass)}>
+                  {hintLabel}
+                </TooltipContent>
+              </Tooltip>
+            </ButtonGroup>
 
-        <Button
-          type="button"
-          variant="outline-secondary"
-          onClick={onToggleHint}
-          size="action"
-          className="flex-1 sm:flex-none min-w-[120px]"
-        >
-          <AppIcon icon={Lightbulb} className="h-4 w-4" aria-hidden="true" />
-          {hintLabel}
-        </Button>
+            <ButtonGroup className="flex-wrap">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="default"
+                    onClick={onReveal}
+                    disabled={isFeedback}
+                    size="icon"
+                    className={cn(utilityBaseClass, revealClass)}
+                    aria-label={revealLabel}
+                  >
+                    <AppIcon icon={MonitorPlay} className="h-4 w-4" aria-hidden="true" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent className={cn(tooltipRedClass, tooltipBaseClass)}>
+                  {revealLabel}
+                </TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="default"
+                    onClick={onSkip}
+                    disabled={isFeedback}
+                    size="icon"
+                    className={cn(utilityBaseClass, skipClass)}
+                    aria-label={skipLabel}
+                  >
+                    <AppIcon icon={SkipForward} className="h-4 w-4" aria-hidden="true" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent className={cn(tooltipGoldClass, tooltipBaseClass)}>
+                  {skipLabel}
+                </TooltipContent>
+              </Tooltip>
+            </ButtonGroup>
 
-        <Button
-          type="button"
-          variant="ghost"
-          onClick={onReveal}
-          disabled={isFeedback}
-          size="action"
-          className="flex-1 sm:flex-none min-w-[120px]"
-        >
-          <AppIcon icon={MonitorPlay} className="h-4 w-4" aria-hidden="true" />
-          {revealLabel}
-        </Button>
+          </div>
 
-        <Button
-          type="button"
-          variant="outline-accent"
-          onClick={onSkip}
-          disabled={isFeedback}
-          size="action"
-          className="flex-1 sm:flex-none min-w-[120px]"
-        >
-          <AppIcon icon={SkipForward} className="h-4 w-4" aria-hidden="true" />
-          {skipLabel}
-        </Button>
-      </div>
+          <ButtonGroup>
+            <Button
+              type="button"
+              variant="default"
+              onClick={onCheck}
+              size="action"
+              className="w-full sm:w-auto bg-[hsl(var(--cymru-green))] text-white hover:bg-[hsl(var(--cymru-green)/0.9)] whitespace-nowrap shadow-sm font-semibold"
+            >
+              <AppIcon icon={CheckCircle2} className="h-5 w-5" aria-hidden="true" />
+              {checkLabel}
+            </Button>
+          </ButtonGroup>
+        </div>
+      </TooltipProvider>
 
       {showHint && hintText ? (
         <div className="rounded-2xl border border-border bg-muted px-4 py-3 text-sm text-foreground">

--- a/src/components/icons/LanguagesIcon.jsx
+++ b/src/components/icons/LanguagesIcon.jsx
@@ -1,0 +1,50 @@
+import React from "react";
+
+const LanguagesIcon = ({
+  size = undefined,
+  color = "#000000",
+  strokeWidth = 2,
+  background = "transparent",
+  opacity = 1,
+  rotation = 0,
+  shadow = 0,
+  flipHorizontal = false,
+  flipVertical = false,
+  padding = 0,
+}) => {
+  const transforms = [];
+  if (rotation !== 0) transforms.push(`rotate(${rotation}deg)`);
+  if (flipHorizontal) transforms.push("scaleX(-1)");
+  if (flipVertical) transforms.push("scaleY(-1)");
+
+  const viewBoxSize = 24 + padding * 2;
+  const viewBoxOffset = -padding;
+  const viewBox = `${viewBoxOffset} ${viewBoxOffset} ${viewBoxSize} ${viewBoxSize}`;
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox={viewBox}
+      width={size}
+      height={size}
+      fill="none"
+      stroke={color}
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      style={{
+        opacity,
+        transform: transforms.join(" ") || undefined,
+        filter:
+          shadow > 0
+            ? `drop-shadow(0 ${shadow}px ${shadow * 2}px rgba(0,0,0,0.3))`
+            : undefined,
+        backgroundColor: background !== "transparent" ? background : undefined,
+      }}
+    >
+      <path d="m5 8l6 6m-7 0l6-6l2-3M2 5h12M7 2h1m14 20l-5-10l-5 10m2-4h6" />
+    </svg>
+  );
+};
+
+export default LanguagesIcon;

--- a/src/i18n/strings.js
+++ b/src/i18n/strings.js
@@ -14,9 +14,11 @@ export const STRINGS = {
     hint: "Awgrym",
     reveal: "Datgelu",
     skip: "Hepgor",
+    shuffle: "Cymysgu",
     next: "Nesaf",
     again: "Eto",
     easy: "Hawdd",
+    hard: "Anodd",
     hear: "Clywed",
     loading: "Llwytho...",
 
@@ -100,9 +102,11 @@ export const STRINGS = {
     hint: "Hint",
     reveal: "Reveal",
     skip: "Skip",
+    shuffle: "Shuffle",
     next: "Next",
     again: "Again",
     easy: "Easy",
+    hard: "Hard",
     hear: "Hear",
     loading: "Loading...",
 


### PR DESCRIPTION
### Motivation
- Keep the mode toggles visually grouped and place the Shuffle control at the end of the row for consistent alignment and responsive behaviour.
- Replace the plain `?` translation hint with a proper translate icon and cymru-green styling so the affordance matches the hero pill and branding.
- Improve hint/reveal/skip button styling and tooltips to use cymru color tokens consistently.

### Description
- Moved Shuffle out of the middle of the mode controls to the far right of the mode-toggle row and conditionally show it only when `mode === "random"` in `src/components/FlashcardArea.jsx`.
- Added a `handleShuffle` path in `src/App.jsx` to emit a `shuffle` result and wired `onShuffle` into the `FlashcardArea` prop list and control handler logic to react to `{ result: "shuffle" }`.
- Introduced a new `LanguagesIcon` component at `src/components/icons/LanguagesIcon.jsx` and replaced the `?` button content with this icon in `PracticeCardFront.jsx` and `PracticeCardChoices.jsx`.
- Restyled the translation hover button and hero-pill border to use cymru-green variables and matching border weight; adjusted hover/tooltip classes to use cymru green for hint and gold/red for other affordances.
- Reworked the front/choices/feedback button area to use grouped icon buttons with `TooltipProvider`/`Tooltip` and `ButtonGroup` to present consistent icon-only controls and a primary action button styled with cymru-green.
- Added i18n strings `shuffle` and `hard` to `src/i18n/strings.js` and threaded `mode` through `PracticeCard` to children where needed.

### Testing
- Started the dev server with `npm run dev` which reported Rollup/Vite ready and served the app locally; server start completed successfully.
- Ran a Playwright script that navigated to the running app and produced a screenshot artifact (`artifacts/mutationtrainer-shuffle-end-lang-icon.png`), confirming the visual placement and new icon render.
- No unit tests were added or executed in this change; visual verification via the screenshot was used and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986793c0c388324a8ea400e7089748b)