### PR TITLE
Record session stats for correct/wrong in random mode

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -174,6 +174,11 @@ export default function App() {
     // Track session stats on graded outcomes (not navigation-only actions)
     if (baseResult === "correct" || baseResult === "wrong") {
       recordResult(baseResult === "correct");
+    } else if (
+      mode === "random" &&
+      (result === "correct" || result === "wrong")
+    ) {
+      recordResult(result === "correct");
     }
 
     if (mode === "smart") {


### PR DESCRIPTION
### Motivation
- Ensure session statistics are updated when a user checks an answer in random mode (`result` is `"correct"` or `"wrong"`) while preserving existing smart-mode (`baseResult`) tracking.

### Description
- Update `onResult` in `src/App.jsx` to call `recordResult(...)` when `mode === "random"` and `payload.result` is `"correct"` or `"wrong"`, while keeping the existing smart-mode `baseResult` handling intact.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986c045aa708324ada1d5f3ff281f57)