### PR TITLE
Increase mobile size for `action` button to h-10

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -31,7 +31,7 @@ const buttonVariants = cva(
       size: {
         default: "h-9 px-4 py-2",
         action:
-          "h-7 px-2 py-1 text-xs sm:h-9 sm:px-4 sm:py-2 sm:text-sm md:h-10 md:px-5 md:text-base lg:h-11 lg:px-6 lg:text-lg",
+          "h-10 px-4 py-2 text-sm sm:h-10 sm:px-5 sm:text-base md:h-11 md:px-6 md:text-lg lg:h-11 lg:px-6 lg:text-lg",
         xs: "h-7 rounded-md px-2 text-xs",
         sm: "h-8 rounded-md px-3 text-xs",
         lg: "h-10 rounded-md px-8",


### PR DESCRIPTION
### Motivation
- Make the `action` size buttons match primary action sizing on small screens so the main action (Check/Next) visually dominates the utility icon buttons in practice cards.

### Description
- Change the `size.action` variant in `src/components/ui/button.tsx` to use `h-10 px-4 py-2 text-sm` as the mobile/default sizing and bump larger breakpoints to `md:h-11`/`md:px-6` so the base mobile height is at least `h-10`.
- Confirmed `src/components/PracticeCardFront.jsx` uses `size="action"` for the primary action button and requires no other changes for the visual hierarchy to take effect.

### Testing
- Started the dev server with `npm run dev` and captured a mobile (375x812) screenshot via Playwright which shows the `size="action"` button is larger than the utility icon buttons on small screens, and the steps completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986c121a92483249c25e6b30b6ae2b0)