### PR TITLE
Adjust PracticeCard responsive sizing and padding

### DIFF
--- a/src/components/PracticeCard.jsx
+++ b/src/components/PracticeCard.jsx
@@ -401,10 +401,10 @@ export default function PracticeCard({
   );
 
   return (
-    <div className="relative w-full max-w-2xl mx-auto">
+    <div className="relative w-full max-w-none sm:max-w-2xl lg:max-w-4xl xl:max-w-5xl mx-auto">
       {!isFeedback && (
         <Card className={cardClassName}>
-          <div className="p-6 sm:p-8">
+          <div className="p-4 sm:p-6 md:p-8">
             {answerMode === "tap" ? (
               <PracticeCardChoices
                 sent={sent}
@@ -458,7 +458,7 @@ export default function PracticeCard({
       {isFeedback && (
         <div className="practice-card-reveal">
           <Card className={cardClassName}>
-            <div className="p-6 sm:p-8">
+            <div className="p-4 sm:p-6 md:p-8">
               <PracticeCardFeedback
                 sent={sent}
                 answer={answer}


### PR DESCRIPTION
### Motivation
- Make the PracticeCard layout responsive so it can go full-width on small screens and constrain to larger max-widths at bigger breakpoints. 
- Ensure inner card content uses responsive padding so text and controls remain comfortable across breakpoints.

### Description
- Replaced the outer wrapper class `max-w-2xl` with `w-full max-w-none sm:max-w-2xl lg:max-w-4xl xl:max-w-5xl mx-auto` in `src/components/PracticeCard.jsx` to enable responsive sizing. 
- Updated content padding from `p-6 sm:p-8` to `p-4 sm:p-6 md:p-8` for both the front and feedback card content blocks in `src/components/PracticeCard.jsx`. 
- Left the internal `cardClassName` intact to preserve the card styling and centering behavior.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and the server came up successfully. 
- Opened the app and captured a page screenshot using a Playwright script against `http://localhost:4173/mutationtrainer-react/`, and the script completed successfully. 
- No unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986c6d3b4a88324bd137cfcafe5b810)