### PR TITLE
Refine inline stats spacing and reduce reset button size

### DIFF
--- a/src/components/SessionStatsCard.jsx
+++ b/src/components/SessionStatsCard.jsx
@@ -92,7 +92,7 @@ export default function SessionStatsCard({ stats, onReset, className }) {
               <TooltipTrigger asChild>
                 <Button
                   variant="outline"
-                  size="sm"
+                  size="xs"
                   onClick={onReset}
                   className="w-full text-muted-foreground hover:text-foreground"
                 >

--- a/src/components/SessionStatsInline.jsx
+++ b/src/components/SessionStatsInline.jsx
@@ -10,15 +10,19 @@ function InlineStat({ icon: Icon, value, label, variant = "default" }) {
   };
 
   return (
-    <div
-      className={cn(
-        "flex items-center gap-1 text-xs font-medium",
-        variantStyles[variant]
-      )}
-      title={label}
-    >
-      <Icon className="h-3 w-3" />
-      <span>{value}</span>
+    <div className="inline-flex items-center gap-1.5" title={label}>
+      <span
+        className={cn(
+          "inline-flex items-center gap-1 text-xs font-semibold",
+          variantStyles[variant]
+        )}
+      >
+        <Icon className="h-3 w-3" />
+        <span>{value}</span>
+      </span>
+      <span className="text-[10px] font-medium text-muted-foreground">
+        {label}
+      </span>
     </div>
   );
 }

--- a/src/i18n/strings.js
+++ b/src/i18n/strings.js
@@ -52,6 +52,11 @@ export const STRINGS = {
     headerNoFocus: "Dim ffocws",
     headerClearFocus: "Clirio ffocws",
     headerSwitchLang: "Newid iaith",
+    sessionStatsTitle: "Ystadegau sesiwn",
+    streakLabel: "Rhediad",
+    accuracyLabel: "Cywirdeb",
+    resetStats: "Ailosod sesiwn",
+    resetStatsHint: "Ailosod rhediad a chywirdeb i sero",
 
     startHereTitle: "Dechrau yma",
     startHereSubtitle: "Canllaw cyflym i ddechrau.",
@@ -140,6 +145,11 @@ export const STRINGS = {
     headerNoFocus: "No focus",
     headerClearFocus: "Clear focus",
     headerSwitchLang: "Switch language",  
+    sessionStatsTitle: "Session stats",
+    streakLabel: "Streak",
+    accuracyLabel: "Accuracy",
+    resetStats: "Reset session",
+    resetStatsHint: "Reset streak and accuracy to zero",
 
     startHereTitle: "Start here",
     startHereSubtitle: "A quick guide to get going.",


### PR DESCRIPTION
### Motivation
- Fix awkward spacing between inline stats and reduce the oversized reset button so the compact stats panel feels balanced and matches the app scale.

### Description
- Tightened the inline stat layout by switching `InlineStat` to an `inline-flex` container with `gap-1.5`, and separated the numeric value (semibold) from the label (10px, medium, muted foreground) in `src/components/SessionStatsInline.jsx`.
- Reduced the reset button size from `sm` to `xs` in `src/components/SessionStatsCard.jsx` so it better fits the card layout.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and the server reported ready (local URL available), which succeeded.
- Ran a Playwright script that navigated to the app and produced `artifacts/session-stats-spacing.png` to visually verify the adjustments, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986c72555008324a491b64007e19adf)