### PR TITLE
Make PracticeCard responsive with updated wrapper and padding

### DIFF
--- a/src/components/PracticeCard.jsx
+++ b/src/components/PracticeCard.jsx
@@ -401,10 +401,10 @@ export default function PracticeCard({
   );
 
   return (
-    <div className="relative w-full max-w-2xl mx-auto">
+    <div className="relative w-full max-w-none sm:max-w-2xl lg:max-w-4xl xl:max-w-5xl mx-auto">
       {!isFeedback && (
         <Card className={cardClassName}>
-          <div className="p-6 sm:p-8">
+          <div className="p-4 sm:p-6 md:p-8">
             {answerMode === "tap" ? (
               <PracticeCardChoices
                 sent={sent}
@@ -458,7 +458,7 @@ export default function PracticeCard({
       {isFeedback && (
         <div className="practice-card-reveal">
           <Card className={cardClassName}>
-            <div className="p-6 sm:p-8">
+            <div className="p-4 sm:p-6 md:p-8">
               <PracticeCardFeedback
                 sent={sent}
                 answer={answer}


### PR DESCRIPTION
### Motivation
- Ensure the PracticeCard scales across viewports by replacing the fixed `max-w-2xl` wrapper with responsive breakpoints so the card width adapts to different screen sizes.
- Keep card content comfortable and readable at all breakpoints by applying responsive padding instead of a single static padding value.

### Description
- Replaced the outer wrapper class in `src/components/PracticeCard.jsx` from `max-w-2xl` to `w-full max-w-none sm:max-w-2xl lg:max-w-4xl xl:max-w-5xl` to provide responsive sizing.
- Updated the card content containers (both front and feedback states) to use responsive padding `p-4 sm:p-6 md:p-8` so spacing is consistent across breakpoints.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and the server launched successfully.
- Ran a Playwright script that opened the app and saved a screenshot to `artifacts/practice-card-responsive.png`, and the script completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986c6d3b4a88324bd137cfcafe5b810)