### PR TITLE
Add TSV-aware parsing to loadCsv and introduce neutral runtime data files

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { PRESET_DEFS } from "./data/presets";
-import { ALL_CSV_FILES } from "./data/csvSources";
+import { ALL_RUNTIME_DATA_FILES } from "./data/csvSources";
 import { loadManyCsvFiles } from "./services/loadCsv";
 import { applyFilters } from "./utils/applyFilters";
 
@@ -68,7 +68,7 @@ export default function App() {
       .replace(/[^a-z0-9]+/g, "");
 
   useEffect(() => {
-    loadManyCsvFiles(ALL_CSV_FILES)
+    loadManyCsvFiles(ALL_RUNTIME_DATA_FILES)
       .then(setRows)
       .catch((e) => console.error(e));
   }, []);

--- a/src/data/csvSources.js
+++ b/src/data/csvSources.js
@@ -9,7 +9,13 @@ export const PROTECTED_MANUAL_CSV_FILES = [
 
 const REGISTERED_UNIT_FILES = ACTIVE_DYSGU_UNITS.map((unit) => unit.file);
 
-export const ALL_CSV_FILES = [...new Set([...PROTECTED_MANUAL_CSV_FILES, ...REGISTERED_UNIT_FILES])];
+// Runtime dataset list for all delimited files (CSV and TSV).
+export const ALL_RUNTIME_DATA_FILES = [
+  ...new Set([...PROTECTED_MANUAL_CSV_FILES, ...REGISTERED_UNIT_FILES]),
+];
+
+// Backwards-compatible alias while call-sites migrate.
+export const ALL_CSV_FILES = ALL_RUNTIME_DATA_FILES;
 
 export const CSV_SOURCE_META = {
   ...Object.fromEntries(
@@ -29,4 +35,3 @@ export const CSV_SOURCE_META = {
     ])
   ),
 };
-

--- a/src/data/csvSources.test.js
+++ b/src/data/csvSources.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { ALL_CSV_FILES, CSV_SOURCE_META, PROTECTED_MANUAL_CSV_FILES } from "./csvSources";
+import { ALL_CSV_FILES, ALL_RUNTIME_DATA_FILES, CSV_SOURCE_META, PROTECTED_MANUAL_CSV_FILES } from "./csvSources";
 
 describe("csv runtime source lock", () => {
   it("keeps protected manual csv files present", () => {
@@ -7,8 +7,9 @@ describe("csv runtime source lock", () => {
   });
 
   it("includes registered unit csv files", () => {
-    expect(ALL_CSV_FILES).toContain("Uwch1/unit1.csv");
-    expect(ALL_CSV_FILES).toContain("Uwch1/unit2.csv");
+    expect(ALL_RUNTIME_DATA_FILES).toContain("Uwch1/unit1.csv");
+    expect(ALL_RUNTIME_DATA_FILES).toContain("Uwch1/unit2.csv");
+    expect(ALL_CSV_FILES).toEqual(ALL_RUNTIME_DATA_FILES);
   });
 
   it("provides source metadata for registered unit csv files", () => {

--- a/src/services/loadCsv.js
+++ b/src/services/loadCsv.js
@@ -162,6 +162,7 @@ function normaliseRow(row, filename, rowIndex) {
 
 export async function loadCsvFromPublicData(filename) {
   const base = import.meta.env.BASE_URL || "/";
+  const isTsv = filename.toLowerCase().endsWith(".tsv");
   // Remove leading slash if base has one and filename has one to avoid //data
   const cleanBase = base.endsWith("/") ? base : `${base}/`;
   const url = `${cleanBase}data/${filename}`;
@@ -175,6 +176,7 @@ export async function loadCsvFromPublicData(filename) {
     const parsed = Papa.parse(csvText, { 
       header: true, 
       skipEmptyLines: true,
+      ...(isTsv ? { delimiter: "\t" } : {}),
       // transforming header is useful but we double-check in normaliseRow
       transformHeader: (h) => {
         return h.trim().toLowerCase().replace(/[^a-z0-9]/g, ""); 

--- a/src/services/loadCsv.test.js
+++ b/src/services/loadCsv.test.js
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { loadCsvFromPublicData } from "./loadCsv";
+
+describe("loadCsvFromPublicData", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("parses CSV files with existing behavior", async () => {
+    const csvText = [
+      "Card ID,Base,Outcome",
+      "card-1,cath,sm",
+    ].join("\n");
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        text: vi.fn().mockResolvedValue(csvText),
+      })
+    );
+
+    const rows = await loadCsvFromPublicData("cards.csv");
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      cardId: "card-1",
+      base: "cath",
+      outcome: "soft",
+      answer: "gath",
+      __source: "cards.csv",
+    });
+  });
+
+  it("parses TSV files into multiple fields", async () => {
+    const tsvText = [
+      "Card ID\tBase\tOutcome",
+      "card-2\tpen\tnm",
+    ].join("\n");
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        text: vi.fn().mockResolvedValue(tsvText),
+      })
+    );
+
+    const rows = await loadCsvFromPublicData("unit-data.TSV");
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      cardId: "card-2",
+      base: "pen",
+      outcome: "nasal",
+      answer: "mhen",
+      __source: "unit-data.TSV",
+    });
+    expect(rows[0]).not.toHaveProperty("cardid\tbase\toutcome");
+  });
+
+  it("keeps fallback cardId behavior", async () => {
+    const csvText = [
+      "Base,Outcome",
+      "bara,sm",
+    ].join("\n");
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        text: vi.fn().mockResolvedValue(csvText),
+      })
+    );
+
+    const rows = await loadCsvFromPublicData("fallback.csv");
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].cardId).toBe("fallback-csv-r2");
+    expect(rows[0]).toMatchObject({
+      base: "bara",
+      outcome: "soft",
+      answer: "fara",
+    });
+  });
+});


### PR DESCRIPTION
### Motivation
- Support tab-separated data files (TSV) when loading public data while preserving existing CSV behavior for backward compatibility.
- Avoid future confusion by introducing a neutral runtime name for the collection of delimited data files instead of implying only CSVs.

### Description
- Detect TSV files in `loadCsvFromPublicData(filename)` using `filename.toLowerCase().endsWith(".tsv")` and set `isTsv` accordingly.
- Pass `delimiter: "\t"` to `Papa.parse` only when `isTsv` is true and keep default CSV parsing for other files.
- Add `ALL_RUNTIME_DATA_FILES` in `src/data/csvSources.js` as a neutral runtime list and keep `ALL_CSV_FILES` as a backwards-compatible alias, then update `App.jsx` to use the neutral list.
- Add unit tests `src/services/loadCsv.test.js` to assert CSV parsing, TSV field parsing, and fallback `cardId` behavior, and update `src/data/csvSources.test.js` to assert the new alias behavior.

### Testing
- Ran `npm test -- src/services/loadCsv.test.js src/data/csvSources.test.js` which executed 2 test files and 6 tests and all passed. 
- The new tests `src/services/loadCsv.test.js` and the updated `src/data/csvSources.test.js` completed successfully with no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aadf4115a483249d05fe60c1f52144)