### PR TITLE
Add canonical TSV header mappings and case-insensitive outcome shortcode handling

### DIFF
--- a/src/services/loadCsv.js
+++ b/src/services/loadCsv.js
@@ -15,12 +15,14 @@ const CANON_MAP = {
   "patternid": "patternId",
   "focus": "focus",
   "qastatus": "qaStatus",
+  "qastatusmnmamnone": "qaStatus",
   
   "rulefamily": "family",
   "family": "family",
   
   "rulecategory": "category",
   "category": "category",
+  "rulecat": "category",
   
   "trigger": "trigger",
   "base": "base",
@@ -37,13 +39,19 @@ const CANON_MAP = {
   "before": "before",
   "after": "after",
   "answer": "answer",
+  "targetword": "answer",
   "outcome": "outcome",
+  "outcomesmnmamnone": "outcome",
+  "outcomessmnmamnone": "outcome",
   "mutation": "outcome",
   
   "translatesent": "translateSent",
   "sentencesmeaning": "translateSent",
+  "sentenceeng": "translateSent",
+  "sentencewithgap": "sentenceWithGap",
   
   "why": "why",
+  "whyeng": "why",
   "whycym": "whyCym",
   "whycymraeg": "whyCym",
   
@@ -84,7 +92,7 @@ function normaliseRow(row, filename, rowIndex) {
     const keyCanon = rawKey.trim().toLowerCase().replace(/[^a-z0-9]/g, "");
     
     // Check map with canonical key
-    const mapped = CANON_MAP[keyCanon];
+    const mapped = CANON_MAP[keyCanon] || (keyCanon.startsWith("qastatus") ? "qaStatus" : undefined);
     if (mapped && cleanVal) {
       out[mapped] = cleanVal;
     }
@@ -107,6 +115,7 @@ function normaliseRow(row, filename, rowIndex) {
     if (raw === "sm") out.outcome = "soft";
     else if (raw === "nm") out.outcome = "nasal";
     else if (raw === "am") out.outcome = "aspirate";
+    else if (raw === "none") out.outcome = "none";
   }
 
   // Lazy generation: answer

--- a/src/services/loadCsv.test.js
+++ b/src/services/loadCsv.test.js
@@ -83,4 +83,54 @@ describe("loadCsvFromPublicData", () => {
       answer: "fara",
     });
   });
+
+  it("normalizes canonicalized TSV headers and outcome shortcodes case-insensitively", async () => {
+    const tsvText = [
+      "Sentence With Gap\tSentence Eng\tTarget Word\tRule Cat\tWhy Eng\tOutcomes (SM/NM/AM/NONE)\tQA Status (SM/NM/AM/NONE)",
+      "Dw i'n _____ nawr\tI am _____ now\tcath\tSubjectBoundary\tTriggers soft mutation\tAm\tNM",
+    ].join("\n");
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        text: vi.fn().mockResolvedValue(tsvText),
+      })
+    );
+
+    const rows = await loadCsvFromPublicData("canonicalized-headers.tsv");
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      sentenceWithGap: "Dw i'n _____ nawr",
+      translateSent: "I am _____ now",
+      answer: "cath",
+      category: "SubjectBoundary",
+      why: "Triggers soft mutation",
+      outcome: "aspirate",
+      qaStatus: "NM",
+      __source: "canonicalized-headers.tsv",
+    });
+  });
+
+  it("maps NONE outcome shortcode case-insensitively", async () => {
+    const tsvText = [
+      "Base\tOutcomes (SM/NM/AM/NONE)",
+      "cath\tNoNe",
+    ].join("\n");
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        text: vi.fn().mockResolvedValue(tsvText),
+      })
+    );
+
+    const rows = await loadCsvFromPublicData("none-outcome.tsv");
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].outcome).toBe("none");
+    expect(rows[0].answer).toBe("cath");
+  });
 });


### PR DESCRIPTION
### Motivation

- TSV exports sometimes produce canonicalized header keys that need mapping into existing internal fields.  
- Outcome shortcodes should be interpreted case-insensitively and support the `NONE` value.  
- Maintain existing legacy header mappings and fallback behavior while supporting new canonicalized variants.

### Description

- Extended `CANON_MAP` in `src/services/loadCsv.js` with canonicalized TSV header aliases such as `sentencewithgap -> sentenceWithGap`, `sentenceeng -> translateSent`, `targetword -> answer`, `rulecat -> category`, and `whyeng -> why`, plus outcome/QA variants like `outcomesmnmamnone`/`outcomessmnmamnone -> outcome` and `qastatusmnmamnone -> qaStatus`.
- Added a fallback that maps any canonicalized header starting with `qastatus` to `qaStatus` to handle `qastatus...` patterns.
- Expanded outcome shortcode normalization to map `SM -> soft`, `NM -> nasal`, `AM -> aspirate`, and `NONE -> none` in a case-insensitive way.
- Kept all legacy mappings and existing fallback logic (cardId fallback, family/category fallbacks, lazy `answer`/sentence generation) unchanged.

### Testing

- Added unit tests in `src/services/loadCsv.test.js` covering canonicalized TSV header mapping and `NONE` outcome handling, and ran `npm test -- src/services/loadCsv.test.js`.
- All tests passed (`5 tests`, file `src/services/loadCsv.test.js`), confirming the new mappings and normalizations work as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aae04946f0832490644e9d86b64759)