### PR TITLE
Handle sentenceWithGap placeholder parsing in CSV loader

### DIFF
--- a/src/services/loadCsv.js
+++ b/src/services/loadCsv.js
@@ -42,6 +42,7 @@ const CANON_MAP = {
   
   "translatesent": "translateSent",
   "sentencesmeaning": "translateSent",
+  "sentencewithgap": "sentenceWithGap",
   
   "why": "why",
   "whycym": "whyCym",
@@ -130,6 +131,29 @@ function normaliseRow(row, filename, rowIndex) {
     // e.g. "Dw i'n {answer} rwan" -> before="Dw i'n ", after=" rwan"
     if (parts.length >= 1) out.before = parts[0].trim();
     if (parts.length >= 2) out.after = parts[1].trim();
+  }
+
+  // Lazy generation: sentences from sentenceWithGap marker.
+  // Supports [], [ ], [  ] and similar whitespace-only placeholders.
+  if (out.sentenceWithGap && !out.before && !out.after) {
+    const markerRegex = /\[\s*\]/;
+    const sentence = out.sentenceWithGap;
+    const markerMatch = sentence.match(markerRegex);
+
+    if (markerMatch) {
+      const markerIndex = markerMatch.index || 0;
+      const markerText = markerMatch[0];
+      const beforePart = sentence.slice(0, markerIndex);
+      const afterPart = sentence.slice(markerIndex + markerText.length);
+
+      out.before = beforePart.replace(/\s+$/, "");
+      out.after = afterPart.replace(/^\s+/, "");
+      out.sentenceWithGap = `${out.before}${out.after ? ` ${out.after}` : ""}`;
+    } else {
+      out.before = sentence.trim();
+      out.after = "";
+      out.sentenceWithGap = out.before;
+    }
   }
 
   // Safety default must remain deterministic for stable review/debug.

--- a/src/services/loadCsv.test.js
+++ b/src/services/loadCsv.test.js
@@ -59,6 +59,81 @@ describe("loadCsvFromPublicData", () => {
     expect(rows[0]).not.toHaveProperty("cardid\tbase\toutcome");
   });
 
+
+  it("derives before/after from sentenceWithGap marker variants", async () => {
+    const csvText = [
+      "Card ID,Sentence With Gap",
+      "card-3,Mae [] hi yma.",
+      "card-4,Roedd [ ] e'n hwyr.",
+      "card-5,Dyma [  ] brawf!",
+      "card-6,Dim marcwr fan hyn.",
+    ].join("\n");
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        text: vi.fn().mockResolvedValue(csvText),
+      })
+    );
+
+    const rows = await loadCsvFromPublicData("sentence-gap.csv");
+
+    expect(rows).toHaveLength(4);
+
+    expect(rows[0]).toMatchObject({
+      cardId: "card-3",
+      before: "Mae",
+      after: "hi yma.",
+      sentenceWithGap: "Mae hi yma.",
+    });
+
+    expect(rows[1]).toMatchObject({
+      cardId: "card-4",
+      before: "Roedd",
+      after: "e'n hwyr.",
+      sentenceWithGap: "Roedd e'n hwyr.",
+    });
+
+    expect(rows[2]).toMatchObject({
+      cardId: "card-5",
+      before: "Dyma",
+      after: "brawf!",
+      sentenceWithGap: "Dyma brawf!",
+    });
+
+    expect(rows[3]).toMatchObject({
+      cardId: "card-6",
+      before: "Dim marcwr fan hyn.",
+      after: "",
+      sentenceWithGap: "Dim marcwr fan hyn.",
+    });
+  });
+
+  it("keeps template {answer} split behavior", async () => {
+    const csvText = [
+      "Card ID,Template",
+      "card-7,Dw i'n {answer} rwan",
+    ].join("\n");
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        text: vi.fn().mockResolvedValue(csvText),
+      })
+    );
+
+    const rows = await loadCsvFromPublicData("template.csv");
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      cardId: "card-7",
+      before: "Dw i'n",
+      after: "rwan",
+    });
+  });
+
   it("keeps fallback cardId behavior", async () => {
     const csvText = [
       "Base,Outcome",


### PR DESCRIPTION
### Motivation
- CSV rows may include a `Sentence With Gap` column using a bracket placeholder for a missing word, and we need to derive `before`/`after` for the UI from that single field.
- Existing `{answer}` template parsing must continue to work for legacy rows.

### Description
- Added canonical header mapping for `sentenceWithGap` so `Sentence With Gap`/`sentencewithgap` CSV headers map to `sentenceWithGap` during normalization.
- Implemented logic in `normaliseRow` to, when `sentenceWithGap` exists and both `before` and `after` are missing, find the first bracket placeholder matching `[]`, `[ ]`, `[  ]` (any whitespace), split the sentence at that marker into `before` and `after`, and remove the marker from the output sentence.
- Trimming preserves natural spacing by only trimming trailing whitespace from the `before` part and leading whitespace from the `after` part, and the final `sentenceWithGap` value is the concatenation of `before` and `after` with a single space when appropriate.
- If no marker is present, the code falls back to `before = full sentence` and `after = ""` so older CSV rows without a marker behave sensibly.
- Left the existing template `{answer}` splitting behavior unchanged so legacy `template` rows still populate `before`/`after` as before.
- Added tests in `src/services/loadCsv.test.js` covering multiple marker variants, the no-marker fallback, and template compatibility.

### Testing
- Ran unit tests with `npm test -- src/services/loadCsv.test.js` and all tests passed.
- Test run summary: 1 test file executed, 5 tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aae11486d4832485f1898796386a48)