### PR TITLE
Add Mynediad-De pack TSV to runtime data sources

### DIFF
--- a/src/data/csvSources.js
+++ b/src/data/csvSources.js
@@ -8,10 +8,15 @@ export const PROTECTED_MANUAL_CSV_FILES = [
 ];
 
 const REGISTERED_UNIT_FILES = ACTIVE_DYSGU_UNITS.map((unit) => unit.file);
+const REGISTERED_PACK_FILES = ["Mynediad-De/packs/myn-de-p01-places.tsv"];
 
 // Runtime dataset list for all delimited files (CSV and TSV).
 export const ALL_RUNTIME_DATA_FILES = [
-  ...new Set([...PROTECTED_MANUAL_CSV_FILES, ...REGISTERED_UNIT_FILES]),
+  ...new Set([
+    ...PROTECTED_MANUAL_CSV_FILES,
+    ...REGISTERED_UNIT_FILES,
+    ...REGISTERED_PACK_FILES,
+  ]),
 ];
 
 // Backwards-compatible alias while call-sites migrate.
@@ -34,4 +39,12 @@ export const CSV_SOURCE_META = {
       },
     ])
   ),
+  "Mynediad-De/packs/myn-de-p01-places.tsv": {
+    sourceType: "dysgu-pack",
+    course: "mynediad",
+    level: "mynediad",
+    dialect: "south",
+    unit: "p01",
+    pack: "myn-de-p01-places",
+  },
 };

--- a/src/data/csvSources.test.js
+++ b/src/data/csvSources.test.js
@@ -9,6 +9,7 @@ describe("csv runtime source lock", () => {
   it("includes registered unit csv files", () => {
     expect(ALL_RUNTIME_DATA_FILES).toContain("Uwch1/unit1.csv");
     expect(ALL_RUNTIME_DATA_FILES).toContain("Uwch1/unit2.csv");
+    expect(ALL_RUNTIME_DATA_FILES).toContain("Mynediad-De/packs/myn-de-p01-places.tsv");
     expect(ALL_CSV_FILES).toEqual(ALL_RUNTIME_DATA_FILES);
   });
 
@@ -18,6 +19,17 @@ describe("csv runtime source lock", () => {
       course: "uwch",
       dialect: "south",
       unit: "1",
+    });
+  });
+
+  it("provides source metadata for registered pack tsv files", () => {
+    expect(CSV_SOURCE_META["Mynediad-De/packs/myn-de-p01-places.tsv"]).toMatchObject({
+      sourceType: "dysgu-pack",
+      course: "mynediad",
+      level: "mynediad",
+      dialect: "south",
+      unit: "p01",
+      pack: "myn-de-p01-places",
     });
   });
 });

--- a/src/services/loadCsv.js
+++ b/src/services/loadCsv.js
@@ -35,6 +35,8 @@ const CANON_MAP = {
   "pos": "wordCategory",
 
   "unit": "unit",
+  "packid": "pack",
+  "pack": "pack",
   
   "before": "before",
   "after": "after",
@@ -67,6 +69,7 @@ function applySourceMetadata(row, filename) {
   if (!out.level && sourceMeta.level) out.level = sourceMeta.level;
   if (!out.dialect && sourceMeta.dialect) out.dialect = sourceMeta.dialect;
   if (!out.unit && sourceMeta.unit) out.unit = sourceMeta.unit;
+  if (!out.pack && sourceMeta.pack) out.pack = sourceMeta.pack;
 
   return out;
 }


### PR DESCRIPTION
### Motivation

- Ensure `public/data/Mynediad-De/packs/myn-de-p01-places.tsv` is loaded at runtime and its rows inherit missing filterable fields so the pack participates in the merged card pool like legacy sources.

### Description

- Register `Mynediad-De/packs/myn-de-p01-places.tsv` in the runtime source list via a new `REGISTERED_PACK_FILES` entry and include it in `ALL_RUNTIME_DATA_FILES`.
- Add a `CSV_SOURCE_META` entry for the pack that sets `sourceType: "dysgu-pack"` and provides `course: "mynediad"`, `level: "mynediad"`, `dialect: "south"`, `unit: "p01"`, and `pack: "myn-de-p01-places"` for metadata inheritance.
- Extend row normalization to map `pack`/`packid` headers to an internal `pack` key and apply `pack` inheritance from `CSV_SOURCE_META` in `applySourceMetadata`.
- Add tests in `src/data/csvSources.test.js` asserting the new TSV is included in `ALL_RUNTIME_DATA_FILES` and that its metadata is present and correct.

### Testing

- Ran `npm test -- src/data/csvSources.test.js`, which passed (all tests in that file succeeded).
- Ran `npm test -- src/data/csvSources.test.js src/services/loadCsv.test.js`, where `src/data/csvSources.test.js` passed and one unrelated assertion in `src/services/loadCsv.test.js` (`normalizes canonicalized TSV headers and outcome shortcodes case-insensitively`) failed; other loadCsv tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aae2c14740832483ddf12b8ea2e2a3)