### PR TITLE
Add Mynediad place-name starter pack and group it in Filters panel

### DIFF
--- a/src/components/FiltersPanel.jsx
+++ b/src/components/FiltersPanel.jsx
@@ -3,7 +3,7 @@ import { HelpCircle, Zap, Filter, BookOpen, Check } from "lucide-react";
 import AppIcon from "./icons/AppIcon";
 import { useI18n } from "../i18n/I18nContext";
 import { cn } from "../lib/cn";
-import { PRESET_DEFS, STARTER_PACK_ORDER } from "../data/presets";
+import { PRESET_DEFS, STARTER_PACK_GROUPS, STARTER_PACK_ORDER } from "../data/presets";
 import DysguCourseUnitPicker from "./filters/DysguCourseUnitPicker";
 
 import {
@@ -135,6 +135,12 @@ export default function FiltersPanel({
 
   const collapsibleProp = accordionType === "single" ? { collapsible: true } : {};
 
+
+  const starterPackGroups =
+    STARTER_PACK_GROUPS?.length
+      ? STARTER_PACK_GROUPS
+      : [{ id: "default", presetIds: STARTER_PACK_ORDER }];
+
   return (
     <div className={cn("space-y-8 py-2 px-1", className)}>
       <Accordion
@@ -220,44 +226,55 @@ export default function FiltersPanel({
               </p>
             </div>
 
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-              {STARTER_PACK_ORDER.map((id) => {
-                const def = PRESET_DEFS[id];
-                const active = activePresetId === id;
-                const label = def?.titleKey ? t(def.titleKey) : def?.title ?? id;
-                const desc = def?.descriptionKey
-                  ? t(def.descriptionKey)
-                  : def?.desc ?? "Practice set";
+            <div className="space-y-4">
+              {starterPackGroups.map((group) => (
+                <div key={group.id} className="space-y-2">
+                  {group.titleKey ? (
+                    <p className="mt-subtitle text-muted-foreground">{t(group.titleKey)}</p>
+                  ) : null}
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                    {group.presetIds.map((id) => {
+                      const def = PRESET_DEFS[id];
+                      if (!def) return null;
 
-                return (
-                  <Button
-                    key={id}
-                    type="button"
-                    variant="ghost"
-                    onClick={() => onTogglePreset?.(active ? null : id)}
-                    className={cn(
-                      "group relative h-auto w-full items-start justify-start rounded-xl border p-4 text-left whitespace-normal break-words overflow-visible transition-all hover:shadow-md",
-                      active
-                        ? "border-2 border-[hsl(var(--cymru-green-light))] bg-primary/10"
-                        : "border-border bg-card hover:border-primary/30"
-                    )}
-                  >
-                    <span className="flex min-w-0 flex-col items-start gap-1 pr-4">
-                      <span className="w-full text-sm font-semibold leading-snug text-foreground transition-colors group-hover:text-primary whitespace-normal break-words">
-                        {label}
-                      </span>
-                      <span className="w-full text-xs text-muted-foreground leading-snug whitespace-normal break-words">
-                        {desc}
-                      </span>
-                    </span>
-                    {active ? (
-                      <span className="absolute -right-1.5 -top-1.5 sm:-right-2 sm:-top-2 inline-flex h-5 w-5 sm:h-6 sm:w-6 items-center justify-center rounded-full border-2 border-card bg-[hsl(var(--cymru-green))] text-white shadow-sm">
-                        <AppIcon icon={Check} className="h-3 w-3 sm:h-3.5 sm:w-3.5" aria-hidden="true" />
-                      </span>
-                    ) : null}
-                  </Button>
-                );
-              })}
+                      const active = activePresetId === id;
+                      const label = def?.titleKey ? t(def.titleKey) : def?.title ?? id;
+                      const desc = def?.descriptionKey
+                        ? t(def.descriptionKey)
+                        : def?.desc ?? "Practice set";
+
+                      return (
+                        <Button
+                          key={id}
+                          type="button"
+                          variant="ghost"
+                          onClick={() => onTogglePreset?.(active ? null : id)}
+                          className={cn(
+                            "group relative h-auto w-full items-start justify-start rounded-xl border p-4 text-left whitespace-normal break-words overflow-visible transition-all hover:shadow-md",
+                            active
+                              ? "border-2 border-[hsl(var(--cymru-green-light))] bg-primary/10"
+                              : "border-border bg-card hover:border-primary/30"
+                          )}
+                        >
+                          <span className="flex min-w-0 flex-col items-start gap-1 pr-4">
+                            <span className="w-full text-sm font-semibold leading-snug text-foreground transition-colors group-hover:text-primary whitespace-normal break-words">
+                              {label}
+                            </span>
+                            <span className="w-full text-xs text-muted-foreground leading-snug whitespace-normal break-words">
+                              {desc}
+                            </span>
+                          </span>
+                          {active ? (
+                            <span className="absolute -right-1.5 -top-1.5 sm:-right-2 sm:-top-2 inline-flex h-5 w-5 sm:h-6 sm:w-6 items-center justify-center rounded-full border-2 border-card bg-[hsl(var(--cymru-green))] text-white shadow-sm">
+                              <AppIcon icon={Check} className="h-3 w-3 sm:h-3.5 sm:w-3.5" aria-hidden="true" />
+                            </span>
+                          ) : null}
+                        </Button>
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
             </div>
           </AccordionContent>
         </AccordionItem>

--- a/src/data/presets.js
+++ b/src/data/presets.js
@@ -33,6 +33,12 @@ const BASE_PRESETS = {
     descriptionKey: "preset.placeNames.desc",
     category: "PlaceName",
   },
+  "mynediad-place-names-pack-01": {
+    id: "mynediad-place-names-pack-01",
+    titleKey: "preset.mynediadPlaceNamesPack01.title",
+    descriptionKey: "preset.mynediadPlaceNamesPack01.desc",
+    sourceScope: ["Mynediad-De/packs/myn-de-p01-places.tsv"],
+  },
 };
 
 // Generate presets from Courses
@@ -72,6 +78,18 @@ export const STARTER_PACK_ORDER = [
   "numbers-1-10",
   "articles",
   "place-names",
+  "mynediad-place-names-pack-01",
 ];
 
+export const STARTER_PACK_GROUPS = [
+  {
+    id: "core",
+    presetIds: ["starter-preps", "numbers-1-10", "articles", "place-names"],
+  },
+  {
+    id: "mynediad",
+    titleKey: "courseMynediad",
+    presetIds: ["mynediad-place-names-pack-01"],
+  },
+];
 

--- a/src/data/presets.test.js
+++ b/src/data/presets.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { PRESET_DEFS, STARTER_PACK_ORDER } from "./presets";
+import { PRESET_DEFS, STARTER_PACK_GROUPS, STARTER_PACK_ORDER } from "./presets";
 
 describe("starter pack curation", () => {
   it("keeps starter pack order curated and excludes all-verified pack", () => {
@@ -12,4 +12,11 @@ describe("starter pack curation", () => {
       STARTER_PACK_ORDER.every((id) => Object.prototype.hasOwnProperty.call(PRESET_DEFS, id))
     ).toBe(true);
   });
+});
+
+
+it("includes Mynediad place-name pack in starter packs and groups", () => {
+  expect(STARTER_PACK_ORDER).toContain("mynediad-place-names-pack-01");
+  const mynediadGroup = STARTER_PACK_GROUPS.find((group) => group.id === "mynediad");
+  expect(mynediadGroup?.presetIds).toContain("mynediad-place-names-pack-01");
 });

--- a/src/i18n/strings.js
+++ b/src/i18n/strings.js
@@ -158,6 +158,8 @@ export const STRINGS = {
     "preset.articles.desc": "Ffocws ar y fannod (Sylfaen).",
     "preset.placeNames.title": "Enwau lleoedd",
     "preset.placeNames.desc": "Cardiau enwau lleoedd ar draws pob CSV.",
+    "preset.mynediadPlaceNamesPack01.title": "Dod o i byw yn",
+    "preset.mynediadPlaceNamesPack01.desc": "Pecyn Mynediad sy’n canolbwyntio ar gymhwyso treiglad meddal a thrwynol i enwau lleoedd Cymraeg.",
 
     // Report mistake
     reportMistake: "Sylwi ar gamgymeriad?",
@@ -331,6 +333,8 @@ export const STRINGS = {
     "preset.articles.desc": "Article focus (Sylfaen).",
     "preset.placeNames.title": "Place names",
     "preset.placeNames.desc": "Place name cards across all CSVs.",
+    "preset.mynediadPlaceNamesPack01.title": "From going to to living in",
+    "preset.mynediadPlaceNamesPack01.desc": "Mynediad pack focused on applying soft and nasal mutation to Welsh place names.",
 
     // Report mistake
     reportMistake: "Noticed a mistake?",

--- a/src/utils/applyFilters.test.js
+++ b/src/utils/applyFilters.test.js
@@ -47,6 +47,13 @@ const rows = [
     outcome: "soft",
     trigger: "i",
   },
+  {
+    cardId: "5",
+    __source: "Mynediad-De/packs/myn-de-p01-places.tsv",
+    category: "PlaceName",
+    outcome: "nasal",
+    trigger: "yn",
+  },
 ];
 
 describe("applyFilters preset extensions", () => {
@@ -98,11 +105,20 @@ describe("applyFilters preset extensions", () => {
     expect(output.map((x) => x.cardId)).toEqual(["4"]);
   });
 
+
+  it("filters by TSV sourceScope for the Mynediad place-name pack", () => {
+    const output = applyFilters(rows, {
+      preset: { sourceScope: ["Mynediad-De/packs/myn-de-p01-places.tsv"] },
+      filters: { families: new Set(), categories: new Set() },
+    });
+    expect(output.map((x) => x.cardId)).toEqual(["5"]);
+  });
+
   it("keeps general pool available when no preset is active", () => {
     const output = applyFilters(rows, {
       preset: null,
       filters: { families: new Set(), categories: new Set() },
     });
-    expect(output.map((x) => x.cardId)).toEqual(["1", "2", "3", "4"]);
+    expect(output.map((x) => x.cardId)).toEqual(["1", "2", "3", "4", "5"]);
   });
 });


### PR DESCRIPTION
### Motivation
- Skills used: none required for this change.
- Add a Mynediad-specific starter pack so users can quickly filter to the Mynediad place-names TSV and practice soft/nasal mutation on Welsh place names.

### Description
- Add a new preset `mynediad-place-names-pack-01` to `src/data/presets.js` with `titleKey`, `descriptionKey`, and `sourceScope: ["Mynediad-De/packs/myn-de-p01-places.tsv"]` so presets can filter by that TSV file.
- Include the new preset in `STARTER_PACK_ORDER` and introduce `STARTER_PACK_GROUPS` to allow a Mynediad sub-title grouping in the Filters panel while preserving the legacy ordering fallback.
- Update `src/components/FiltersPanel.jsx` to render grouped starter packs (with a fallback to the original `STARTER_PACK_ORDER` behavior) and wire the preset buttons to existing `onTogglePreset` handling so selection filters correctly.
- Add i18n keys in `src/i18n/strings.js` for Welsh and English `title`/`desc` for the new pack and add tests to validate inclusion and sourceScope filtering.

### Testing
- Ran unit tests for the modified areas with `vitest` for `src/utils/applyFilters.test.js` and `src/data/presets.test.js`, and all tests passed (`11 passed`).
- `npm run lint` was executed and failed due to pre-existing lint issues unrelated to these changes (errors in `CardUtilityCluster.jsx` and `DysguCourseUnitPicker.jsx`).
- Started the dev server and inspected the Filters UI to confirm the grouped Starter Packs render (manual verification / screenshot taken during the rollout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aae3aa902c832491201ca99a9bbd36)