### PR TITLE
Normalize and set Vite `base` from env (WM_BASE_PATH / VITE_BASE_PATH)

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -11,7 +11,16 @@ export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
   Object.assign(process.env, env);
 
+  const configuredBase = String(
+    env.WM_BASE_PATH || env.VITE_BASE_PATH || "/"
+  ).trim();
+
+  const normalizedBase = configuredBase.endsWith("/")
+    ? configuredBase
+    : `${configuredBase}/`;
+
   return {
+    base: normalizedBase,
     plugins: [react(), tailwindcss(), viteAdminApiPlugin()],
     resolve: {
       alias: {


### PR DESCRIPTION
### Motivation
- Ensure Vite `base` is configurable via `WM_BASE_PATH` or `VITE_BASE_PATH` and always includes a trailing slash to avoid asset resolution issues.

### Description
- Load environment variables and derive `configuredBase` from `WM_BASE_PATH` or `VITE_BASE_PATH` with a fallback of `/`, normalize it to always end with a slash, and set `base: normalizedBase` in the exported Vite config.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae88add7b48324ba8209f8cb00efb8)