### PR TITLE
Add WM_BASE_PATH and run build before preview with improved start script error handling

### DIFF
--- a/deploy/systemd/mutationtrainer.env.example
+++ b/deploy/systemd/mutationtrainer.env.example
@@ -5,6 +5,7 @@ WM_ADMIN_PASSWORD=change-me
 PORT=4173
 WM_BIND_HOST=0.0.0.0
 WM_ADMIN_SESSION_TTL_HOURS=12
+WM_BASE_PATH=/mutationtrainer-react/
 
 # Optional (used by reverse proxy assumptions)
 NODE_ENV=production

--- a/scripts/start-prod.cjs
+++ b/scripts/start-prod.cjs
@@ -33,18 +33,53 @@ function resolveViteBin() {
   return path.resolve(path.dirname(pkgJsonPath), binEntry);
 }
 
-const args = ["preview", "--host", host, "--port", port];
-const viteBin = resolveViteBin();
+function runViteCommand(viteBin, args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [viteBin, ...args], {
+      stdio: "inherit",
+      env: process.env,
+    });
 
-const child = spawn(process.execPath, [viteBin, ...args], {
-  stdio: "inherit",
-  env: process.env,
-});
+    child.on("error", reject);
 
-child.on("exit", (code, signal) => {
-  if (signal) {
-    process.kill(process.pid, signal);
-    return;
+    child.on("exit", (code, signal) => {
+      if (signal) {
+        process.kill(process.pid, signal);
+        return;
+      }
+
+      if ((code ?? 0) !== 0) {
+        reject(new Error(`Vite command failed: ${args.join(" ")} (exit ${code ?? 0})`));
+        return;
+      }
+
+      resolve();
+    });
+  });
+}
+
+(async () => {
+  const viteBin = resolveViteBin();
+
+  try {
+    await runViteCommand(viteBin, ["build"]);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
   }
-  process.exit(code ?? 0);
-});
+
+  const previewArgs = ["preview", "--host", host, "--port", port];
+
+  const previewChild = spawn(process.execPath, [viteBin, ...previewArgs], {
+    stdio: "inherit",
+    env: process.env,
+  });
+
+  previewChild.on("exit", (code, signal) => {
+    if (signal) {
+      process.kill(process.pid, signal);
+      return;
+    }
+    process.exit(code ?? 0);
+  });
+})();

--- a/vite.config.js
+++ b/vite.config.js
@@ -11,7 +11,16 @@ export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
   Object.assign(process.env, env);
 
+  const configuredBase = String(
+    env.WM_BASE_PATH || env.VITE_BASE_PATH || "/"
+  ).trim();
+
+  const normalizedBase = configuredBase.endsWith("/")
+    ? configuredBase
+    : `${configuredBase}/`;
+
   return {
+    base: normalizedBase,
     plugins: [react(), tailwindcss(), viteAdminApiPlugin()],
     resolve: {
       alias: {


### PR DESCRIPTION
### Motivation
- Allow the app to be served from a sub-path by introducing a configurable base path for assets and routing via an environment variable.  
- Ensure the production start script builds the frontend before running the Vite preview and surface build errors correctly.  

### Description
- Add `WM_BASE_PATH` to `deploy/systemd/mutationtrainer.env.example` as a runtime option.  
- In `vite.config.js` read `WM_BASE_PATH` (falling back to `VITE_BASE_PATH` or `/`), normalize it to always end with a slash, and set Vite's `base` option accordingly.  
- Refactor `scripts/start-prod.cjs` to extract a `runViteCommand` promise wrapper, run `vite build` first and fail fast on build errors, then spawn `vite preview` and propagate exit codes/signals.  
- Improve error reporting from the start script by rejecting on child process errors and non-zero exit codes.  

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae88add7b48324ba8209f8cb00efb8)