### PR TITLE
Refine shadcn Badge hover behavior for filter chips

### DIFF
--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -21,17 +21,17 @@ const badgeVariants = cva(
         outline:
           "border-border bg-transparent text-foreground hover:bg-secondary/15",
         "cymru-dark":
-          "border-transparent bg-[hsl(var(--cymru-green))] text-[hsl(var(--cymru-white))] hover:bg-[hsl(var(--cymru-green)/0.9)]",
+          "border-transparent bg-[hsl(var(--cymru-green))] text-[hsl(var(--cymru-white))] hover:bg-[hsl(var(--cymru-green)/0.85)]",
         "cymru-light":
           "border-transparent bg-[hsl(var(--cymru-green-light))] text-[hsl(var(--cymru-white))] hover:bg-[hsl(var(--cymru-green-light)/0.9)]",
         "cymru-dark-wash":
-          "border-transparent bg-[hsl(var(--cymru-green-wash))] text-[hsl(var(--cymru-green))] hover:bg-[hsl(var(--cymru-green-wash)/0.85)]",
+          "border-transparent bg-[hsl(var(--cymru-green)/0.14)] text-[hsl(var(--cymru-green))] hover:bg-[hsl(var(--cymru-green)/0.24)]",
         "cymru-light-wash":
           "border-transparent bg-[hsl(var(--cymru-green-light)/0.2)] text-[hsl(var(--cymru-green))] hover:bg-[hsl(var(--cymru-green-light)/0.3)]",
         "cymru-gold":
-          "border-transparent bg-[hsl(var(--cymru-gold))] text-[hsl(var(--cymru-white))] hover:bg-[hsl(var(--cymru-gold)/0.9)]",
+          "border-transparent bg-[hsl(var(--cymru-gold))] text-[hsl(var(--cymru-white))] hover:bg-[hsl(var(--cymru-gold)/0.85)]",
         "cymru-gold-wash":
-          "border-transparent bg-[hsl(var(--cymru-gold-wash))] text-[hsl(var(--cymru-gold))] hover:bg-[hsl(var(--cymru-gold-wash)/0.85)]",
+          "border-transparent bg-[hsl(var(--cymru-gold)/0.14)] text-[hsl(var(--cymru-gold))] hover:bg-[hsl(var(--cymru-gold)/0.24)]",
         ghost: "border-border bg-transparent hover:bg-muted",
         warning:
           "border-[hsl(var(--cymru-red)/0.3)] bg-transparent text-[hsl(var(--cymru-red))] hover:bg-[hsl(var(--cymru-red-wash))] hover:border-[hsl(var(--cymru-red)/0.5)]",


### PR DESCRIPTION
### Motivation
- The category filter badges already had a subtle hover affordance but the level and mutation-type filter chips did not, so the shared badge tokens were adjusted (not a one-off component) to give a consistent, color-appropriate hover effect.

### Description
- Updated shared shadcn `Badge` variant tokens in `src/components/ui/badge.tsx` to soften active hover for `cymru-dark` and `cymru-gold` and to redefine `cymru-dark-wash` / `cymru-gold-wash` as alpha overlays of their base colors so wash variants gain a subtle hover contrast.

### Testing
- Ran `npm run test -- --run src/utils/applyFilters.test.js` which passed (8 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af2be65f7c8324a4121a58c5a56e42)